### PR TITLE
Permission update

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,6 +12,7 @@ commands:
     shopkeeper:
         description: Base for all shopkeeper commands.
         aliases: [shopkeepers]
+        permission: shopkeeper.help
         usage: 'Unknown command! Try /<command> help'
 
 permissions:


### PR DESCRIPTION
This update will mean that players wont see the /shopkeepers in tabcomplete unless they have the permission to use it.