### PR TITLE
feature: set an custom placeholder item type

### DIFF
--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -618,7 +618,7 @@ public class Settings extends Config {
 		// Certain items cannot be of type AIR:
 		if (placeholderItem.getType() == Material.AIR) {
 			Log.warning(this.getLogPrefix() + "'placeholder-item' can not be AIR.");
-			placeholderItem = placeholderItem.withType(Material.PAPER);
+			placeholderItem = placeholderItem.withType(Material.NAME_TAG);
 		}
 		if (shopCreationItem.getType() == Material.AIR) {
 			Log.warning(this.getLogPrefix() + "'shop-creation-item' can not be AIR.");

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -297,7 +297,7 @@ public class Settings extends Config {
 
 		public static ItemData namingItemData;
 
-		public static ItemData placeholderItem;
+		public static ItemData placeholderItemData;
 
 		// Button items:
 		public static ItemData nameButtonItem;
@@ -338,7 +338,7 @@ public class Settings extends Config {
 
 			// Ignore (clear) the display name, which is used to specify the new shopkeeper name, but keep the lore:
 			namingItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
-			placeholderItem = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)));
+			placeholderItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)));
 
 			// Button items:
 			nameButtonItem = new ItemData(nameItem, Messages.buttonName, Messages.buttonNameLore);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -338,7 +338,7 @@ public class Settings extends Config {
 
 			// Ignore (clear) the display name, which is used to specify the new shopkeeper name, but keep the lore:
 			namingItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
-			placeholderItem = Settings.placeholderItem;
+			placeholderItem = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)));
 
 			// Button items:
 			nameButtonItem = new ItemData(nameItem, Messages.buttonName, Messages.buttonNameLore);
@@ -616,10 +616,6 @@ public class Settings extends Config {
 			mobBehaviorTickPeriod = 1;
 		}
 		// Certain items cannot be of type AIR:
-		if (placeholderItem.getType() == Material.AIR) {
-			Log.warning(this.getLogPrefix() + "'placeholder-item' can not be AIR.");
-			placeholderItem = placeholderItem.withType(Material.NAME_TAG);
-		}
 		if (shopCreationItem.getType() == Material.AIR) {
 			Log.warning(this.getLogPrefix() + "'shop-creation-item' can not be AIR.");
 			shopCreationItem = shopCreationItem.withType(Material.VILLAGER_SPAWN_EGG);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -64,6 +64,8 @@ public class Settings extends Config {
 	public static boolean convertAllPlayerItems = true;
 	public static List<ItemData> convertPlayerItemsExceptions = new ArrayList<>();
 
+	public static ItemData placeholderItem = new ItemData(Material.NAME_TAG);
+
 	/*
 	 * Plugin Compatibility
 	 */
@@ -295,6 +297,8 @@ public class Settings extends Config {
 
 		public static ItemData namingItemData;
 
+		public static ItemData placeholderItem;
+
 		// Button items:
 		public static ItemData nameButtonItem;
 		public static ItemData containerButtonItem;
@@ -334,6 +338,7 @@ public class Settings extends Config {
 
 			// Ignore (clear) the display name, which is used to specify the new shopkeeper name, but keep the lore:
 			namingItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
+			placeholderItem = Settings.placeholderItem;
 
 			// Button items:
 			nameButtonItem = new ItemData(nameItem, Messages.buttonName, Messages.buttonNameLore);
@@ -611,6 +616,10 @@ public class Settings extends Config {
 			mobBehaviorTickPeriod = 1;
 		}
 		// Certain items cannot be of type AIR:
+		if (placeholderItem.getType() == Material.AIR) {
+			Log.warning(this.getLogPrefix() + "'placeholder-item' can not be AIR.");
+			placeholderItem = placeholderItem.withType(Material.PAPER);
+		}
 		if (shopCreationItem.getType() == Material.AIR) {
 			Log.warning(this.getLogPrefix() + "'shop-creation-item' can not be AIR.");
 			shopCreationItem = shopCreationItem.withType(Material.VILLAGER_SPAWN_EGG);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -64,8 +64,6 @@ public class Settings extends Config {
 	public static boolean convertAllPlayerItems = true;
 	public static List<ItemData> convertPlayerItemsExceptions = new ArrayList<>();
 
-	public static ItemData placeholderItem = new ItemData(Material.NAME_TAG);
-
 	/*
 	 * Plugin Compatibility
 	 */
@@ -216,6 +214,8 @@ public class Settings extends Config {
 	public static ItemData currentPageItem = new ItemData(Material.WRITABLE_BOOK);
 	public static ItemData tradeSetupItem = new ItemData(Material.PAPER);
 
+	public static ItemData placeholderItem = new ItemData(Material.NAME_TAG);
+
 	public static ItemData nameItem = new ItemData(Material.NAME_TAG);
 
 	public static boolean enableContainerOptionOnPlayerShop = true;
@@ -295,9 +295,9 @@ public class Settings extends Config {
 
 		public static Charset fileCharset;
 
-		public static ItemData namingItemData;
-
 		public static ItemData placeholderItemData;
+
+		public static ItemData namingItemData;
 
 		// Button items:
 		public static ItemData nameButtonItem;
@@ -336,9 +336,11 @@ public class Settings extends Config {
 				fileCharset = StandardCharsets.UTF_8;
 			}
 
-			// Ignore (clear) the display name, which is used to specify the new shopkeeper name, but keep the lore:
-			namingItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
+			// Ignore (clear) the display name that is used to specify the substituted item type:
 			placeholderItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)));
+
+			// Ignore (clear) the display name that is used to specify the new shopkeeper name, but keep the lore:
+			namingItemData = new ItemData(UnmodifiableItemStack.of(ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
 
 			// Button items:
 			nameButtonItem = new ItemData(nameItem, Messages.buttonName, Messages.buttonNameLore);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
@@ -1,23 +1,17 @@
 package com.nisovin.shopkeepers.shopkeeper.player;
 
-import com.nisovin.shopkeepers.config.Settings;
-import com.nisovin.shopkeepers.config.lib.Config;
-import com.nisovin.shopkeepers.config.lib.ConfigHelper;
-import com.nisovin.shopkeepers.util.bukkit.ConfigUtils;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils.EnchantmentEntry;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.inventory.PotionUtils;
-
-import java.util.Objects;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Helper methods related to placeholder items.

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
@@ -1,5 +1,11 @@
 package com.nisovin.shopkeepers.shopkeeper.player;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
@@ -7,11 +13,6 @@ import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils.EnchantmentEntry;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.inventory.PotionUtils;
-import org.bukkit.ChatColor;
-import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Helper methods related to placeholder items.
@@ -45,8 +46,7 @@ public class PlaceholderItems {
 	 * @return <code>true</code> if the item stack is of the type used by placeholder items
 	 */
 	public static boolean isPlaceholderItemType(@ReadOnly ItemStack itemStack) {
-		if (itemStack == null) return false;
-		if (itemStack.getType() != Settings.placeholderItem.getType()) return false;
+		if (Settings.placeholderItem.matches(itemStack)) return false;
 		// TODO: is there an easier way for comparing current items name with the original one?
 		if (itemStack.hasItemMeta()) {
 			ItemMeta meta = itemStack.getItemMeta();

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
@@ -7,7 +7,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
-import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.config.Settings.DerivedSettings;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils.EnchantmentEntry;
@@ -46,7 +46,7 @@ public class PlaceholderItems {
 	 * @return <code>true</code> if the item stack is of the type used by placeholder items
 	 */
 	public static boolean isPlaceholderItemType(@ReadOnly ItemStack itemStack) {
-		return Settings.placeholderItem.matches(itemStack);
+		return DerivedSettings.placeholderItemData.matches(itemStack);
 	}
 
 	/**

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
@@ -46,16 +46,7 @@ public class PlaceholderItems {
 	 * @return <code>true</code> if the item stack is of the type used by placeholder items
 	 */
 	public static boolean isPlaceholderItemType(@ReadOnly ItemStack itemStack) {
-		if (Settings.placeholderItem.matches(itemStack)) return false;
-		// TODO: is there an easier way for comparing current items name with the original one?
-		if (itemStack.hasItemMeta()) {
-			ItemMeta meta = itemStack.getItemMeta();
-			assert meta != null;
-			if (Settings.placeholderItem.getItemMeta().getDisplayName().equals(meta.getDisplayName())) {
-				return false;
-			}
-		}
-		return true;
+		return Settings.placeholderItem.matches(itemStack);
 	}
 
 	/**

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlaceholderItems.java
@@ -1,5 +1,9 @@
 package com.nisovin.shopkeepers.shopkeeper.player;
 
+import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.config.lib.Config;
+import com.nisovin.shopkeepers.config.lib.ConfigHelper;
+import com.nisovin.shopkeepers.util.bukkit.ConfigUtils;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -12,6 +16,8 @@ import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils;
 import com.nisovin.shopkeepers.util.inventory.EnchantmentUtils.EnchantmentEntry;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.inventory.PotionUtils;
+
+import java.util.Objects;
 
 /**
  * Helper methods related to placeholder items.
@@ -46,7 +52,15 @@ public class PlaceholderItems {
 	 */
 	public static boolean isPlaceholderItemType(@ReadOnly ItemStack itemStack) {
 		if (itemStack == null) return false;
-		if (itemStack.getType() != Material.NAME_TAG) return false;
+		if (itemStack.getType() != Settings.placeholderItem.getType()) return false;
+		// TODO: is there an easier way for comparing current items name with the original one?
+		if (itemStack.hasItemMeta()) {
+			ItemMeta meta = itemStack.getItemMeta();
+			assert meta != null;
+			if (Settings.placeholderItem.getItemMeta().getDisplayName().equals(meta.getDisplayName())) {
+				return false;
+			}
+		}
 		return true;
 	}
 

--- a/modules/main/src/main/resources/config.yml
+++ b/modules/main/src/main/resources/config.yml
@@ -388,7 +388,7 @@ current-page-item: WRITABLE_BOOK
 trade-setup-item: PAPER
 
 # The item that players can rename and then use as a substitute for items they
-# don't yet have when setting up trades.
+# don't have yet when they set up their trade offers.
 # Set this to AIR to disable the use of placeholder items.
 placeholder-item: NAME_TAG
 

--- a/modules/main/src/main/resources/config.yml
+++ b/modules/main/src/main/resources/config.yml
@@ -95,9 +95,6 @@ convert-player-items: false
 convert-all-player-items: true
 # Black- or whitelist of items affected by the 'convert-player-items' setting.
 convert-player-items-exceptions: []
-# This material type declares which items will be seen as placeholder items.
-# These can be named on an Anvil with the specific type.
-placeholder-item: NAME_TAG
 
 # *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
 # Plugin Compatibility
@@ -389,6 +386,11 @@ previous-page-item: WRITABLE_BOOK
 next-page-item: WRITABLE_BOOK
 current-page-item: WRITABLE_BOOK
 trade-setup-item: PAPER
+
+# The item that players can rename and then use as a substitute for items they
+# don't yet have when setting up trades.
+# Set this to AIR to disable the use of placeholder items.
+placeholder-item: NAME_TAG
 
 # The item used for the set-name button, and the naming item (if enabled).
 name-item: NAME_TAG

--- a/modules/main/src/main/resources/config.yml
+++ b/modules/main/src/main/resources/config.yml
@@ -95,6 +95,9 @@ convert-player-items: false
 convert-all-player-items: true
 # Black- or whitelist of items affected by the 'convert-player-items' setting.
 convert-player-items-exceptions: []
+# This material type declares which items will be seen as placeholder items.
+# These can be named on an Anvil with the specific type.
+placeholder-item: NAME_TAG
 
 # *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
 # Plugin Compatibility


### PR DESCRIPTION
Being limited to the name tag can be quite difficult on survival servers. Allowing to use custom items for placeholder items, like a paper, makes the use of this feature way easier.

## Tested

Tested on PaperMC 1.17.1 with `NAME_TAG` and `PAPER` using the names via the anvil: `Diamond`. Invalid config has the fallback to name tag.

## Notes
I'm unsure in regards to the check of the display name. Maybe there is another easier/cleaner way (it has been quite some time since my last Java Code).