### PR TITLE
Add SQLite TradeLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Date format: (YYYY-MM-DD)
 ## v2.23.1 (TBA)
 ### Supported MC versions: 1.21.1, 1.21, 1.20.6
 
+* Add SQLite based trade log storage. (Thanks @akshualy)
+  * In the future, this can be used for additional features, such as offline trade notifications.
+  * Config: Add new setting `trade-log-storage`. Available values: `DISABLED` (default), `SQLITE` (recommended), `CSV`.
+  * Config: Add migration from the old `log-trades-to-csv` to the new `trade-log-storage` setting.
+  * Only one storage type can be selected: Logging trades to both CSV and the SQLite is not supported.
+  * Internal: Refactors to share most of the logic between the old CSV and the new SQLite trade loggers.
 * Config: Remove `file-encoding` setting: We use Bukkit to load the save data, which always expects the data to be UTF-8 encoded.
 
 ## v2.23.0 (2024-08-11)

--- a/modules/external-annotations/src/main/resources/java/sql/DriverManager.eea
+++ b/modules/external-annotations/src/main/resources/java/sql/DriverManager.eea
@@ -1,0 +1,37 @@
+class java/sql/DriverManager
+deregisterDriver
+ (Ljava/sql/Driver;)V
+ (L0java/sql/Driver;)V
+drivers
+ ()Ljava/util/stream/Stream<Ljava/sql/Driver;>;
+ ()L1java/util/stream/Stream<L1java/sql/Driver;>;
+getConnection
+ (Ljava/lang/String;)Ljava/sql/Connection;
+ (L1java/lang/String;)L1java/sql/Connection;
+getConnection
+ (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/sql/Connection;
+ (L1java/lang/String;L0java/lang/String;L0java/lang/String;)L1java/sql/Connection;
+getConnection
+ (Ljava/lang/String;Ljava/util/Properties;)Ljava/sql/Connection;
+ (L1java/lang/String;Ljava/util/Properties;)L1java/sql/Connection;
+getDriver
+ (Ljava/lang/String;)Ljava/sql/Driver;
+ (L1java/lang/String;)L1java/sql/Driver;
+getDrivers
+ ()Ljava/util/Enumeration<Ljava/sql/Driver;>;
+ ()L1java/util/Enumeration<L1java/sql/Driver;>;
+getDrivers
+ (Ljava/lang/Class<*>;)Ljava/util/List<Ljava/sql/Driver;>;
+ (L0java/lang/Class<*>;)L1java/util/List<L1java/sql/Driver;>;
+getLogWriter
+ ()Ljava/io/PrintWriter;
+ ()L0java/io/PrintWriter;
+registerDriver
+ (Ljava/sql/Driver;)V
+ (L1java/sql/Driver;)V
+registerDriver
+ (Ljava/sql/Driver;Ljava/sql/DriverAction;)V
+ (L1java/sql/Driver;L0java/sql/DriverAction;)V
+setLogWriter
+ (Ljava/io/PrintWriter;)V
+ (L0java/io/PrintWriter;)V

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -47,7 +47,7 @@ public class Settings extends Config {
 	/*
 	 * General Settings
 	 */
-	public static int configVersion = 7;
+	public static int configVersion = 8;
 	public static boolean debug = false;
 	// See DebugOptions for all available options.
 	public static List<String> debugOptions = new ArrayList<>(0);
@@ -350,7 +350,7 @@ public class Settings extends Config {
 	public static int tradeLogMergeDurationTicks = 300; // 15 seconds
 	public static int tradeLogNextMergeTimeoutTicks = 100; // 5 seconds
 
-	public static boolean logTradesToCsv = false;
+	public static String tradeLogStorage = "";
 
 	public static boolean logItemMetadata = false;
 

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -33,6 +33,7 @@ import com.nisovin.shopkeepers.playershops.MaxShopsPermission;
 import com.nisovin.shopkeepers.playershops.PlayerShopsLimit;
 import com.nisovin.shopkeepers.shopcreation.ShopCreationItem;
 import com.nisovin.shopkeepers.shopkeeper.TradingRecipeDraft;
+import com.nisovin.shopkeepers.tradelog.TradeLogStorageType;
 import com.nisovin.shopkeepers.util.bukkit.ConfigUtils;
 import com.nisovin.shopkeepers.util.bukkit.EntityUtils;
 import com.nisovin.shopkeepers.util.bukkit.SoundEffect;
@@ -347,10 +348,10 @@ public class Settings extends Config {
 	/*
 	 * Trade Log
 	 */
+	public static TradeLogStorageType tradeLogStorage = TradeLogStorageType.DISABLED;
+
 	public static int tradeLogMergeDurationTicks = 300; // 15 seconds
 	public static int tradeLogNextMergeTimeoutTicks = 100; // 5 seconds
-
-	public static String tradeLogStorage = "";
 
 	public static boolean logItemMetadata = false;
 

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
@@ -1,8 +1,9 @@
 package com.nisovin.shopkeepers.config.migration;
 
-import com.nisovin.shopkeepers.util.data.container.DataContainer;
-
 import static com.nisovin.shopkeepers.config.migration.ConfigMigrationHelper.*;
+
+import com.nisovin.shopkeepers.tradelog.TradeLogStorageType;
+import com.nisovin.shopkeepers.util.data.container.DataContainer;
 
 /**
  * Migrates the config from version 7 to version 8.
@@ -11,9 +12,14 @@ public class ConfigMigration8 implements ConfigMigration {
 
 	@Override
 	public void apply(DataContainer configData) {
-		// Remove the log-trades-to-csv setting in favor of being able to configure the trade log
-		// storage via the new trade-log-storage:
+		// Replace the 'log-trades-to-csv' setting in favor of the 'new trade-log-storage' setting:
+		// We preserve the enabled logging state.
+		boolean logTradesToCsv = configData.getBoolean("log-trades-to-csv");
 		removeSetting(configData, "log-trades-to-csv");
-		addSetting(configData, "trade-log-storage", "");
+		addSetting(
+				configData,
+				"trade-log-storage",
+				logTradesToCsv ? TradeLogStorageType.CSV : TradeLogStorageType.DISABLED
+		);
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
@@ -1,0 +1,19 @@
+package com.nisovin.shopkeepers.config.migration;
+
+import com.nisovin.shopkeepers.util.data.container.DataContainer;
+
+import static com.nisovin.shopkeepers.config.migration.ConfigMigrationHelper.*;
+
+/**
+ * Migrates the config from version 7 to version 8.
+ */
+public class ConfigMigration8 implements ConfigMigration {
+
+	@Override
+	public void apply(DataContainer configData) {
+		// Remove the log-trades-to-csv setting in favor of being able to configure the trade log
+		// storage via the new trade-log-storage:
+		removeSetting(configData, "log-trades-to-csv");
+		addSetting(configData, "trade-log-storage", "");
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigration8.java
@@ -19,7 +19,8 @@ public class ConfigMigration8 implements ConfigMigration {
 		addSetting(
 				configData,
 				"trade-log-storage",
-				logTradesToCsv ? TradeLogStorageType.CSV : TradeLogStorageType.DISABLED
+				logTradesToCsv ? TradeLogStorageType.CSV.name()
+						: TradeLogStorageType.DISABLED.name()
 		);
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigrations.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/migration/ConfigMigrations.java
@@ -21,7 +21,8 @@ public class ConfigMigrations {
 			new ConfigMigration4(),
 			new ConfigMigration5(),
 			new ConfigMigration6(),
-			new ConfigMigration7()
+			new ConfigMigration7(),
+			new ConfigMigration8()
 	);
 
 	public static int getLatestVersion() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/metrics/FeaturesChart.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/metrics/FeaturesChart.java
@@ -114,8 +114,8 @@ public class FeaturesChart extends Metrics.DrilldownPie {
 			);
 			addFeatureEntry(
 					allFeatures,
-					"log-trades-to-csv",
-					Settings.logTradesToCsv
+					"trade-log-storage",
+					Settings.tradeLogStorage
 			);
 			addFeatureEntry(
 					allFeatures,

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogStorageType.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogStorageType.java
@@ -1,0 +1,11 @@
+package com.nisovin.shopkeepers.tradelog;
+
+/**
+ * The available trade log storage types.
+ */
+public enum TradeLogStorageType {
+
+	DISABLED,
+	SQLITE,
+	CSV
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogUtils.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogUtils.java
@@ -1,0 +1,45 @@
+package com.nisovin.shopkeepers.tradelog;
+
+import java.util.Map;
+
+import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import com.nisovin.shopkeepers.util.yaml.YamlUtils;
+
+/**
+ * Helpers related to the logging of trades.
+ */
+public class TradeLogUtils {
+
+	// Note: We log the item metadata in Yaml format, since this is what Bukkit natively supports
+	// for serializing and deserializing ItemStacks. This ensures that we are able to load the data
+	// again and recreate the original ItemStack if we wish to.
+	// An alternative would be to log it in Json format, which may have better library support
+	// across languages. However:
+	// - Yaml is a super set of Json, so it is not guaranteed to be able to represent all future
+	// serialized items, because certain Yaml features (e.g. object aliases / references) are not
+	// supported.
+	// - Gson (the Json library included with the Minecraft server and Bukkit) will not properly
+	// preserve certain data types by default (at least not if we don't provide detailed custom
+	// deserializers for every type of data that we may want to deserialize, or a deserializer that
+	// replicates Yaml's parsing of certain primitive types, which is actually not that easily
+	// possible): For instance, if the numeric data type of a loaded Json number is unknown, Gson
+	// loads it as a double by default (without there being an easy way to change that). But since
+	// some parts of Bukkit's ItemStack deserialization have strict expectations regarding the type
+	// of data to deserialize, the deserialization from Json may fail for this data.
+	public static String getItemMetadata(UnmodifiableItemStack itemStack) {
+		assert itemStack != null;
+		// If the logging of item metadata is enabled (not checked here), we not only store the
+		// item's ItemMeta (if it has any), but also its data version. We therefore serialize the
+		// complete item stack here, but then remove the item's type and amount again, since these
+		// properties are already getting stored separately.
+		Map<String, Object> itemData = itemStack.serialize(); // Assert: Modifiable map.
+		itemData.remove("type");
+		itemData.remove("amount");
+		// In order to ensure single-line CSV records, we format the Yaml compactly:
+		String yaml = YamlUtils.toCompactYaml(itemData);
+		return yaml;
+	}
+
+	private TradeLogUtils() {
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLogger.java
@@ -5,6 +5,12 @@ import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
 public interface TradeLogger {
 
 	/**
+	 * This is invoked once to perform any required one-time setup prior to the first trades being
+	 * logged.
+	 */
+	public void setup();
+
+	/**
 	 * Logs the given {@link TradeRecord}.
 	 * <p>
 	 * The actual writing to storage might happen asynchronously or in batches. Use {@link #flush()}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
@@ -3,6 +3,7 @@ package com.nisovin.shopkeepers.tradelog;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.nisovin.shopkeepers.tradelog.sqlite.SQLiteTradeLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -55,8 +56,13 @@ public class TradeLoggers implements Listener {
 		assert tradeMerger != null;
 		tradeMerger.onEnable();
 
-		if (Settings.logTradesToCsv) {
-			loggers.add(new CsvTradeLogger(plugin));
+		switch (Settings.tradeLogStorage) {
+			case "csv":
+				loggers.add(new CsvTradeLogger(plugin));
+				break;
+			case "sqlite":
+				loggers.add(new SQLiteTradeLogger(plugin));
+				break;
 		}
 
 		Bukkit.getPluginManager().registerEvents(this, plugin);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
@@ -3,7 +3,6 @@ package com.nisovin.shopkeepers.tradelog;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.nisovin.shopkeepers.tradelog.sqlite.SQLiteTradeLogger;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -17,6 +16,7 @@ import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.tradelog.csv.CsvTradeLogger;
 import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
+import com.nisovin.shopkeepers.tradelog.sqlite.SQLiteTradeLogger;
 import com.nisovin.shopkeepers.util.java.Validate;
 import com.nisovin.shopkeepers.util.trading.MergedTrades;
 import com.nisovin.shopkeepers.util.trading.TradeMerger;
@@ -57,12 +57,15 @@ public class TradeLoggers implements Listener {
 		tradeMerger.onEnable();
 
 		switch (Settings.tradeLogStorage) {
-			case "csv":
-				loggers.add(new CsvTradeLogger(plugin));
-				break;
-			case "sqlite":
-				loggers.add(new SQLiteTradeLogger(plugin));
-				break;
+		case CSV:
+			loggers.add(new CsvTradeLogger(plugin));
+			break;
+		case SQLITE:
+			loggers.add(new SQLiteTradeLogger(plugin));
+			break;
+		case DISABLED:
+		default:
+			break;
 		}
 
 		Bukkit.getPluginManager().registerEvents(this, plugin);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/TradeLoggers.java
@@ -68,6 +68,8 @@ public class TradeLoggers implements Listener {
 			break;
 		}
 
+		loggers.forEach(TradeLogger::setup);
+
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
 

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/AbstractFileTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/AbstractFileTradeLogger.java
@@ -1,0 +1,30 @@
+package com.nisovin.shopkeepers.tradelog.base;
+
+import java.nio.file.Path;
+
+import org.bukkit.plugin.Plugin;
+
+import com.nisovin.shopkeepers.tradelog.TradeLogStorageType;
+import com.nisovin.shopkeepers.tradelog.TradeLogger;
+
+/**
+ * Base class for file-based {@link TradeLogger}s with a single concurrent writer.
+ */
+public abstract class AbstractFileTradeLogger extends AbstractSingleWriterTradeLogger {
+
+	/**
+	 * The directory inside the plugin folder to store trade logs in.
+	 */
+	public static final String TRADE_LOGS_FOLDER = "trade-logs";
+
+	/**
+	 * The path of the trade logs directory.
+	 */
+	protected final Path tradeLogsFolder;
+
+	public AbstractFileTradeLogger(Plugin plugin, TradeLogStorageType storageType) {
+		super(plugin, storageType);
+
+		this.tradeLogsFolder = plugin.getDataFolder().toPath().resolve(TRADE_LOGS_FOLDER);
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/AbstractSingleWriterTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/AbstractSingleWriterTradeLogger.java
@@ -1,0 +1,499 @@
+package com.nisovin.shopkeepers.tradelog.base;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.scheduler.BukkitTask;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
+import com.nisovin.shopkeepers.api.internal.util.Unsafe;
+import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.tradelog.TradeLogStorageType;
+import com.nisovin.shopkeepers.tradelog.TradeLogUtils;
+import com.nisovin.shopkeepers.tradelog.TradeLogger;
+import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
+import com.nisovin.shopkeepers.util.bukkit.PermissionUtils;
+import com.nisovin.shopkeepers.util.bukkit.SchedulerUtils;
+import com.nisovin.shopkeepers.util.bukkit.SingletonTask;
+import com.nisovin.shopkeepers.util.java.CollectionUtils;
+import com.nisovin.shopkeepers.util.java.Retry;
+import com.nisovin.shopkeepers.util.java.ThrowableUtils;
+import com.nisovin.shopkeepers.util.java.Validate;
+import com.nisovin.shopkeepers.util.java.VoidCallable;
+import com.nisovin.shopkeepers.util.logging.Log;
+
+/**
+ * Base class for {@link TradeLogger}s with a single concurrent writer. Trades are buffered and
+ * periodically persisted in batches.
+ * <p>
+ * If any initial setup is required, override {@link #preSetup()}, {@link #asyncSetup()} and
+ * {@link #postSetup()} accordingly.
+ */
+public abstract class AbstractSingleWriterTradeLogger implements TradeLogger {
+
+	private static final int DELAYED_SAVE_TICKS = 600; // 30 seconds
+
+	private static final int SAVE_MAX_ATTEMPTS = 20;
+	private static final long SAVE_RETRY_DELAY_MILLIS = 25L;
+	private static final long SAVE_ERROR_MSG_THROTTLE_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+	protected final Plugin plugin;
+	protected final TradeLogStorageType storageType;
+	protected final String logPrefix;
+
+	private final SetupTask setupTask;
+	private boolean setupCompleted = false;
+
+	private boolean enabled = true;
+
+	private List<TradeRecord> pending = new ArrayList<>();
+	private final SaveTask saveTask;
+	private @Nullable BukkitTask delayedSaveTask = null;
+	// This is reset to the current configuration value prior to every save. This ensures that the
+	// value of this setting remains constant during the save and does not differ for the items of
+	// the trades that are being saved as part of the same batch.
+	private boolean logItemMetadata;
+
+	public AbstractSingleWriterTradeLogger(Plugin plugin, TradeLogStorageType storageType) {
+		Validate.notNull(plugin, "plugin is null");
+		this.plugin = plugin;
+		this.storageType = storageType;
+		this.logPrefix = storageType.toString() + " trade log: ";
+		this.setupTask = new SetupTask(plugin);
+		this.saveTask = new SaveTask(plugin);
+	}
+
+	@Override
+	public final void setup() {
+		if (setupCompleted) return;
+		if (setupTask.isRunning()) return;
+
+		setupTask.run();
+	}
+
+	/**
+	 * Override this to perform any setup that needs to happen on the server's main thread before
+	 * {@link #asyncSetup()} is invoked.
+	 */
+	protected void preSetup() {
+	}
+
+	/**
+	 * Override this to perform any asynchronous setup.
+	 * <p>
+	 * If the setup fails, consider calling {@link #disable(String)} during {@link #postSetup()}.
+	 * <p>
+	 * In certain circumstances, such as the plugin shutting down again before the setup has been
+	 * completed, this might also be called on the main thread.
+	 */
+	protected void asyncSetup() {
+	}
+
+	/**
+	 * Override this to perform any setup that needs to happen on the server's main thread after
+	 * {@link #asyncSetup()} completes.
+	 */
+	protected void postSetup() {
+	}
+
+	private class SetupTask extends SingletonTask {
+
+		private SetupTask(Plugin plugin) {
+			super(plugin);
+		}
+
+		private class InternalAsyncTask extends SingletonTask.InternalAsyncTask {
+		}
+
+		private class InternalSyncCallbackTask extends SingletonTask.InternalSyncCallbackTask {
+		}
+
+		@Override
+		protected InternalAsyncTask createInternalAsyncTask() {
+			return new InternalAsyncTask();
+		}
+
+		@Override
+		protected InternalSyncCallbackTask createInternalSyncCallbackTask() {
+			return new InternalSyncCallbackTask();
+		}
+
+		@Override
+		protected void prepare() {
+			preSetup();
+		}
+
+		@Override
+		protected void execute() {
+			asyncSetup();
+		}
+
+		@Override
+		protected void syncCallback() {
+			postSetup();
+			setupCompleted = true;
+
+			// Save any pending trades that were buffered while the setup was in progress:
+			savePending();
+		}
+	}
+
+	/**
+	 * Call this to disable this trade logger, e.g. if the setup has failed. Trades won't be logged.
+	 * 
+	 * @param reason
+	 *            the reason
+	 */
+	protected final void disable(String reason) {
+		if (!SchedulerUtils.isMainThread()) {
+			throw new IllegalStateException("This must be called from the server's main thread!");
+		}
+
+		Log.severe(logPrefix + "Disabled (trades won't be logged)! Reason: " + reason);
+		enabled = false;
+		this.cancelDelayedSave();
+		pending.clear();
+	}
+
+	@Override
+	public void logTrade(TradeRecord trade) {
+		if (!enabled) return;
+
+		pending.add(trade);
+
+		// It is likely for there to be additional trades to log in the immediate future. In order
+		// to reduce IO overhead, we do not trigger a save right away, but buffer the incoming trade
+		// records over a short period of time.
+		this.savePendingDelayed();
+	}
+
+	@Override
+	public void flush() {
+		setupTask.awaitExecutions();
+		this.savePending();
+		saveTask.awaitExecutions();
+	}
+
+	private boolean hasPending() {
+		return !pending.isEmpty();
+	}
+
+	private void savePendingDelayed() {
+		if (!setupCompleted) {
+			// Any pending trades are saved once the setup completes.
+			return;
+		}
+
+		if (!this.hasPending()) {
+			// There are no pending trades to save:
+			return;
+		}
+
+		if (delayedSaveTask != null) {
+			// There is already a delayed save in progress:
+			return;
+		}
+
+		delayedSaveTask = SchedulerUtils.runTaskLaterOrOmit(
+				plugin,
+				new DelayedSaveTask(),
+				DELAYED_SAVE_TICKS
+		);
+	}
+
+	private class DelayedSaveTask implements Runnable {
+		@Override
+		public void run() {
+			delayedSaveTask = null;
+			savePending();
+		}
+	}
+
+	private void cancelDelayedSave() {
+		if (delayedSaveTask != null) {
+			delayedSaveTask.cancel();
+			delayedSaveTask = null;
+		}
+	}
+
+	private void savePending() {
+		assert setupCompleted;
+		if (!this.hasPending()) {
+			// There are no pending trades to save:
+			return;
+		}
+
+		saveTask.run(); // Usually async, but may be sync during plugin disable
+	}
+
+	private class SaveTask extends SingletonTask {
+
+		private List<TradeRecord> saving = new ArrayList<>();
+		private @Nullable SaveContext saveContext = null;
+		private boolean saveSucceeded = false;
+		private long lastSaveErrorMsgMillis = 0L;
+
+		private SaveTask(Plugin plugin) {
+			super(plugin);
+		}
+
+		private class InternalAsyncTask extends SingletonTask.InternalAsyncTask {
+		}
+
+		private class InternalSyncCallbackTask extends SingletonTask.InternalSyncCallbackTask {
+		}
+
+		@Override
+		protected InternalAsyncTask createInternalAsyncTask() {
+			return new InternalAsyncTask();
+		}
+
+		@Override
+		protected InternalSyncCallbackTask createInternalSyncCallbackTask() {
+			return new InternalSyncCallbackTask();
+		}
+
+		@Override
+		protected void prepare() {
+			// Stop any active delayed save task:
+			cancelDelayedSave();
+
+			// Reset local logItemMetadata setting:
+			logItemMetadata = Settings.logItemMetadata;
+
+			// Swap the pending and saving lists of trades:
+			assert saving.isEmpty();
+			List<TradeRecord> temp = saving;
+			saving = pending;
+			pending = temp;
+
+			// Setup new SaveContext:
+			assert saveContext == null;
+			this.saveContext = new SaveContext(saving);
+		}
+
+		@Override
+		protected void execute() {
+			SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
+			saveSucceeded = writeTradesWithRetry(saveContext);
+			assert saveSucceeded ? !saveContext.hasUnsavedTrades() : saveContext.hasUnsavedTrades();
+		}
+
+		@Override
+		protected void syncCallback() {
+			SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
+
+			this.printDebugInfo();
+
+			if (!saveSucceeded) {
+				// Save failed:
+
+				// Add the unsaved trades to the front of the pending trades:
+				pending.addAll(0, saveContext.getUnsavedTrades());
+
+				// Attempt the save again after a short delay:
+				// However, during the final save attempt during plugin disable, this is skipped and
+				// data might be lost.
+				savePendingDelayed();
+
+				// Inform admins about the issue (throttled to once every x minutes):
+				long nowMillis = System.currentTimeMillis();
+				if (Math.abs(nowMillis - lastSaveErrorMsgMillis) > SAVE_ERROR_MSG_THROTTLE_MILLIS) {
+					lastSaveErrorMsgMillis = nowMillis;
+					String errorMsg = ChatColor.DARK_RED + "[Shopkeepers] " + ChatColor.RED
+							+ logPrefix + "Failed to log trades!"
+							+ " Please check the server logs and look into the issue!";
+					for (Player player : Bukkit.getOnlinePlayers()) {
+						assert player != null;
+						if (PermissionUtils.hasPermission(player, ShopkeepersPlugin.ADMIN_PERMISSION)) {
+							player.sendMessage(errorMsg);
+						}
+					}
+				}
+			}
+
+			// Reset:
+			this.saveContext = null;
+			saving.clear();
+		}
+
+		private void printDebugInfo() {
+			Log.debug(() -> {
+				SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
+
+				StringBuilder sb = new StringBuilder();
+				sb.append("Logged trades to the ");
+				sb.append(storageType);
+				sb.append(" trade log (");
+
+				// Number of logged trade records:
+				sb.append(saving.size()).append(" records");
+
+				// Number of trade records that we failed to log:
+				if (saveContext.hasUnsavedTrades()) {
+					sb.append(", ")
+							.append(saveContext.getUnsavedTrades().size())
+							.append(" failed to log");
+				}
+
+				// Timing summary:
+				sb.append("): ");
+				sb.append(this.getExecutionTimingString());
+
+				// Failure indicator:
+				if (!saveSucceeded) {
+					if (saveContext.getUnsavedTrades().size() == saving.size()) {
+						sb.append(" -- Logging failed!");
+					} else {
+						sb.append(" -- Logging partially failed!");
+					}
+				}
+				return sb.toString();
+			});
+		}
+	}
+
+	/**
+	 * The context for a particular invocation of the save task to persist a batch of trade records.
+	 */
+	protected static class SaveContext {
+
+		private final List<? extends TradeRecord> trades;
+		private int nextUnsaved = 0;
+
+		private SaveContext(List<? extends TradeRecord> trades) {
+			assert trades != null && !CollectionUtils.containsNull(trades);
+			this.trades = trades;
+		}
+
+		/**
+		 * Checks if there are any remaining trades in this batch that need to be persisted.
+		 * 
+		 * @return <code>true</code> if there are unsaved trades for the current batch
+		 */
+		public boolean hasUnsavedTrades() {
+			return (nextUnsaved < trades.size());
+		}
+
+		/**
+		 * Gets the next unsaved {@link TradeRecord} of this batch.
+		 * <p>
+		 * Call {@link #onTradeSuccessfullySaved()} once the trade record has been successfully
+		 * persisted to move the cursor forward.
+		 * 
+		 * @return the next trade record to persist, or <code>null</code> if there are no more
+		 *         trades to persist in this batch
+		 */
+		public @Nullable TradeRecord getNextUnsavedTrade() {
+			if (!this.hasUnsavedTrades()) return null;
+			return trades.get(nextUnsaved);
+		}
+
+		// May return a sublist view:
+		private List<? extends TradeRecord> getUnsavedTrades() {
+			if (!this.hasUnsavedTrades()) {
+				return Collections.emptyList();
+			} else {
+				return trades.subList(nextUnsaved, trades.size());
+			}
+		}
+
+		/**
+		 * This must be called after successfully persisting the {@link TradeRecord} returned by
+		 * {@link #getNextUnsavedTrade()}.
+		 */
+		public void onTradeSuccessfullySaved() {
+			nextUnsaved++;
+		}
+	}
+
+	/**
+	 * Gets a compact (one line) string representation of the item's metadata.
+	 * 
+	 * @param itemStack
+	 *            the item
+	 * @return the item's metadata, or an empty string if {@link Settings#logItemMetadata} is
+	 *         <code>false</code>.
+	 */
+	protected String getItemMetadata(UnmodifiableItemStack itemStack) {
+		assert itemStack != null;
+		if (!logItemMetadata) return ""; // Disabled
+
+		return TradeLogUtils.getItemMetadata(itemStack);
+	}
+
+	// May be invoked asynchronously.
+	// Returns true on success.
+	private boolean writeTradesWithRetry(SaveContext saveContext) {
+		try {
+			Retry.retry((VoidCallable) () -> {
+				this.writeTrades(saveContext);
+			}, SAVE_MAX_ATTEMPTS, (attemptNumber, exception, retry) -> {
+				// Trade logging failed:
+				assert exception != null;
+				// Don't spam with errors and stacktraces: Only print them once for the first failed
+				// saving attempt (and again for the last failed attempt), and otherwise log a
+				// compact description of the issue:
+				String errorMsg = logPrefix + "Failed to log trades (attempt " + attemptNumber + ")";
+				if (attemptNumber == 1) {
+					Log.severe(errorMsg, exception);
+				} else {
+					String issue = ThrowableUtils.getDescription(exception);
+					Log.severe(errorMsg + ": " + issue);
+				}
+
+				// Try again after a small delay:
+				if (retry) {
+					try {
+						Thread.sleep(SAVE_RETRY_DELAY_MILLIS);
+					} catch (InterruptedException e) {
+						// Restore the interrupt status for anyone interested in it, but otherwise
+						// ignore the interrupt here, because we prefer to keep retrying to still
+						// save the data to disk after all:
+						Thread.currentThread().interrupt();
+					}
+				}
+			});
+			return true;
+		} catch (Exception e) {
+			Log.severe(logPrefix + "Failed to log trades! Data might have been lost! :(", e);
+			return false;
+		}
+	}
+
+	/**
+	 * Persists the remaining unsaved trades of the given {@link SaveContext}.
+	 * <p>
+	 * Implementation notes:
+	 * <ul>
+	 * <li>Reliably persist all trades.
+	 * <li>Persist trades in the order in which they occurred.
+	 * <li>Persist individual trades atomically, i.e. not partially, intertwined, or duplicated
+	 * (e.g. if we retry failed log attempts).
+	 * <li>Usually invoked asynchronously, but may be invoked on the server's main thread, for
+	 * example during plugin shutdown.
+	 * </ul>
+	 * <p>
+	 * If the saving of a trade record fails, i.e. if this method throws an exception, this method
+	 * may be invoked again several times after short delays with the same {@link SaveContext} in
+	 * order to retry the saving of the remaining trade records of the batch. If the saving still
+	 * cannot be completed after several retries, the failed save attempt is logged and admins are
+	 * informed. If the plugin is currently shutting down, the data for any unsaved trades is lost.
+	 * Otherwise, if the plugin is not shutting down, we re-attempt the saving of the unsaved trade
+	 * records as part of the next batch.
+	 * 
+	 * @param saveContext
+	 *            the save context
+	 * @throws Exception
+	 *             if the saving fails
+	 */
+	protected abstract void writeTrades(SaveContext saveContext) throws Exception;
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/package-info.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/base/package-info.java
@@ -1,0 +1,2 @@
+@org.eclipse.jdt.annotation.NonNullByDefault
+package com.nisovin.shopkeepers.tradelog.base;

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/csv/CsvTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/csv/CsvTradeLogger.java
@@ -10,47 +10,29 @@ import java.nio.file.StandardOpenOption;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
-import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
-import com.nisovin.shopkeepers.config.Settings;
-import com.nisovin.shopkeepers.tradelog.TradeLogUtils;
-import com.nisovin.shopkeepers.tradelog.TradeLogger;
+import com.nisovin.shopkeepers.tradelog.TradeLogStorageType;
+import com.nisovin.shopkeepers.tradelog.base.AbstractFileTradeLogger;
 import com.nisovin.shopkeepers.tradelog.data.PlayerRecord;
 import com.nisovin.shopkeepers.tradelog.data.ShopRecord;
 import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
-import com.nisovin.shopkeepers.util.bukkit.PermissionUtils;
-import com.nisovin.shopkeepers.util.bukkit.SchedulerUtils;
-import com.nisovin.shopkeepers.util.bukkit.SingletonTask;
 import com.nisovin.shopkeepers.util.csv.CsvFormatter;
-import com.nisovin.shopkeepers.util.java.CollectionUtils;
 import com.nisovin.shopkeepers.util.java.FileUtils;
-import com.nisovin.shopkeepers.util.java.Retry;
 import com.nisovin.shopkeepers.util.java.StringUtils;
-import com.nisovin.shopkeepers.util.java.ThrowableUtils;
-import com.nisovin.shopkeepers.util.java.Validate;
-import com.nisovin.shopkeepers.util.java.VoidCallable;
 import com.nisovin.shopkeepers.util.logging.Log;
 
 /**
  * Logs trades to CSV files.
  */
-public class CsvTradeLogger implements TradeLogger {
+public class CsvTradeLogger extends AbstractFileTradeLogger {
 
-	private static final String TRADE_LOGS_FOLDER = "trade-logs";
 	private static final String FILE_NAME_PREFIX = "trades-";
 	private static final List<? extends String> CSV_HEADER = Collections.unmodifiableList(Arrays.asList(
 			"time",
@@ -82,14 +64,7 @@ public class CsvTradeLogger implements TradeLogger {
 			.withZone(Unsafe.assertNonNull(ZoneId.systemDefault()));
 	private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
 			.withZone(Unsafe.assertNonNull(ZoneId.systemDefault()));
-	private static final int DELAYED_SAVE_TICKS = 600; // 30 seconds
 
-	private static final int SAVE_MAX_ATTEMPTS = 20;
-	private static final long SAVE_RETRY_DELAY_MILLIS = 25L;
-	private static final long SAVE_ERROR_MSG_THROTTLE_MILLIS = TimeUnit.MINUTES.toMillis(5);
-
-	private final Plugin plugin;
-	private final Path tradeLogsFolder;
 	// Note: Even though the CSV format allows quoted fields to span across multiple lines, we want
 	// each CSV record to only span a single line. However, even though we do not want fields to
 	// contain unescaped newlines, we do not escape these newlines via the CSV formatter. Instead,
@@ -99,251 +74,15 @@ public class CsvTradeLogger implements TradeLogger {
 	private final CsvFormatter csv = new CsvFormatter()
 			.escapeNewlines(false)
 			.warnOnNewlines();
-	private List<TradeRecord> pending = new ArrayList<>();
-	private final SaveTask saveTask;
-	private @Nullable BukkitTask delayedSaveTask = null;
-	// This is reset to the current configuration value prior to every save. This ensures that the
-	// value of this setting remains constant during the save and does not differ for the items of
-	// the trades that are being saved as part of the same batch.
-	private boolean logItemMetadata;
 
 	public CsvTradeLogger(Plugin plugin) {
-		Validate.notNull(plugin, "plugin is null");
-		this.plugin = plugin;
-		this.tradeLogsFolder = plugin.getDataFolder().toPath().resolve(TRADE_LOGS_FOLDER);
-		this.saveTask = new SaveTask(plugin);
-	}
-
-	@Override
-	public void logTrade(TradeRecord trade) {
-		pending.add(trade);
-
-		// We do not trigger a save right away, because it is likely for there to be more trades to
-		// log in the immediate future:
-		this.savePendingDelayed();
-	}
-
-	@Override
-	public void flush() {
-		this.savePending();
-		saveTask.awaitExecutions();
-	}
-
-	private boolean isDirty() {
-		return !pending.isEmpty();
-	}
-
-	private void savePendingDelayed() {
-		if (!this.isDirty()) {
-			// There are no pending trades to save:
-			return;
-		}
-		if (delayedSaveTask != null) {
-			// There is already a delayed save in progress:
-			return;
-		}
-
-		delayedSaveTask = SchedulerUtils.runTaskLaterOrOmit(
-				plugin,
-				new DelayedSaveTask(),
-				DELAYED_SAVE_TICKS
-		);
-	}
-
-	private class DelayedSaveTask implements Runnable {
-		@Override
-		public void run() {
-			delayedSaveTask = null;
-			savePending();
-		}
-	}
-
-	private void cancelDelayedSave() {
-		if (delayedSaveTask != null) {
-			delayedSaveTask.cancel();
-			delayedSaveTask = null;
-		}
-	}
-
-	private void savePending() {
-		if (!this.isDirty()) {
-			// There are no pending trades to save:
-			return;
-		}
-		saveTask.run(); // Usually async, but may be sync during plugin disable
-	}
-
-	private class SaveTask extends SingletonTask {
-
-		private List<TradeRecord> saving = new ArrayList<>();
-		private @Nullable SaveContext saveContext = null;
-		private boolean saveSucceeded = false;
-		private long lastSaveErrorMsgMillis = 0L;
-
-		SaveTask(Plugin plugin) {
-			super(plugin);
-		}
-
-		private class InternalAsyncTask extends SingletonTask.InternalAsyncTask {
-		}
-
-		private class InternalSyncCallbackTask extends SingletonTask.InternalSyncCallbackTask {
-		}
-
-		@Override
-		protected InternalAsyncTask createInternalAsyncTask() {
-			return new InternalAsyncTask();
-		}
-
-		@Override
-		protected InternalSyncCallbackTask createInternalSyncCallbackTask() {
-			return new InternalSyncCallbackTask();
-		}
-
-		@Override
-		protected void prepare() {
-			// Stop any active delayed save task:
-			cancelDelayedSave();
-
-			// Reset local logItemMetadata setting:
-			logItemMetadata = Settings.logItemMetadata;
-
-			// Swap the pending and saving lists of trades:
-			assert saving.isEmpty();
-			List<TradeRecord> temp = saving;
-			saving = pending;
-			pending = temp;
-
-			// Setup new SaveContext:
-			assert saveContext == null;
-			this.saveContext = new SaveContext(saving);
-		}
-
-		@Override
-		protected void execute() {
-			SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
-			saveSucceeded = writeTradesToDisk(saveContext);
-			assert saveSucceeded ? !saveContext.hasUnsavedTrades() : saveContext.hasUnsavedTrades();
-		}
-
-		@Override
-		protected void syncCallback() {
-			SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
-
-			this.printDebugInfo();
-
-			if (!saveSucceeded) {
-				// Save failed:
-
-				// Add the unsaved trades to the front of the pending trades:
-				pending.addAll(0, saveContext.getUnsavedTrades());
-
-				// Attempt the save again after a short delay:
-				// However, during the final save attempt during plugin disable, this is skipped and
-				// data might be lost.
-				savePendingDelayed();
-
-				// Inform admins about the issue (throttled to once every 5 minutes):
-				long nowMillis = System.currentTimeMillis();
-				if (Math.abs(nowMillis - lastSaveErrorMsgMillis) > SAVE_ERROR_MSG_THROTTLE_MILLIS) {
-					lastSaveErrorMsgMillis = nowMillis;
-					String errorMsg = ChatColor.DARK_RED + "[Shopkeepers] " + ChatColor.RED
-							+ "Logging trades to the CSV trade log failed!"
-							+ " Please check the server logs and look into the issue!";
-					for (Player player : Bukkit.getOnlinePlayers()) {
-						assert player != null;
-						if (PermissionUtils.hasPermission(player, ShopkeepersPlugin.ADMIN_PERMISSION)) {
-							player.sendMessage(errorMsg);
-						}
-					}
-				}
-			}
-
-			// Reset:
-			this.saveContext = null;
-			saving.clear();
-		}
-
-		private void printDebugInfo() {
-			Log.debug(() -> {
-				SaveContext saveContext = Unsafe.assertNonNull(this.saveContext);
-
-				StringBuilder sb = new StringBuilder();
-				sb.append("Logged trades to the CSV trade log (");
-
-				// Number of logged trade records:
-				sb.append(saving.size()).append(" records");
-
-				// Number of trade records that we failed to log:
-				if (saveContext.hasUnsavedTrades()) {
-					sb.append(", ")
-							.append(saveContext.getUnsavedTrades().size())
-							.append(" failed to log");
-				}
-
-				// Timing summary:
-				sb.append("): ");
-				sb.append(this.getExecutionTimingString());
-
-				// Failure indicator:
-				if (!saveSucceeded) {
-					if (saveContext.getUnsavedTrades().size() == saving.size()) {
-						sb.append(" -- Logging failed!");
-					} else {
-						sb.append(" -- Logging partially failed!");
-					}
-				}
-				return sb.toString();
-			});
-		}
-	}
-
-	private static class SaveContext {
-
-		private final List<? extends TradeRecord> trades;
-		private int nextUnsaved = 0;
-
-		SaveContext(List<? extends TradeRecord> trades) {
-			assert trades != null && !CollectionUtils.containsNull(trades);
-			this.trades = trades;
-		}
-
-		public boolean hasUnsavedTrades() {
-			return (nextUnsaved < trades.size());
-		}
-
-		// Returns null if there are no more unsaved trades.
-		// Does not move the cursor forward until onTradeSuccessfullySaved() has been called.
-		public @Nullable TradeRecord getNextUnsavedTrade() {
-			if (!this.hasUnsavedTrades()) return null;
-			return trades.get(nextUnsaved);
-		}
-
-		// May return a sublist view:
-		public List<? extends TradeRecord> getUnsavedTrades() {
-			if (!this.hasUnsavedTrades()) {
-				return Collections.emptyList();
-			} else {
-				return trades.subList(nextUnsaved, trades.size());
-			}
-		}
-
-		public void onTradeSuccessfullySaved() {
-			nextUnsaved++;
-		}
+		super(plugin, TradeLogStorageType.CSV);
 	}
 
 	private Path getLogFile(Instant timestamp) {
 		assert timestamp != null;
 		String fileName = FILE_NAME_PREFIX + DATE_FORMAT.format(timestamp) + ".csv";
 		return tradeLogsFolder.resolve(fileName);
-	}
-
-	private String getItemMetadata(UnmodifiableItemStack itemStack) {
-		assert itemStack != null;
-		if (!logItemMetadata) return ""; // Disabled
-
-		return TradeLogUtils.getItemMetadata(itemStack);
 	}
 
 	private String toCSVRecord(TradeRecord trade) {
@@ -397,61 +136,10 @@ public class CsvTradeLogger implements TradeLogger {
 		));
 	}
 
-	// May be invoked asynchronously.
-	// Returns true on success.
-	public boolean writeTradesToDisk(SaveContext saveContext) {
-		try {
-			Retry.retry((VoidCallable) () -> {
-				this.writeTradesToLogFile(saveContext);
-			}, SAVE_MAX_ATTEMPTS, (attemptNumber, exception, retry) -> {
-				// Trade logging failed:
-				assert exception != null;
-				// Don't spam with errors and stacktraces: Only print them once for the first failed
-				// saving attempt (and again for the last failed attempt), and otherwise log a
-				// compact description of the issue:
-				String errorMsg = "Failed to log trades to the CSV trade log (attempt "
-						+ attemptNumber + ")";
-				if (attemptNumber == 1) {
-					Log.severe(errorMsg, exception);
-				} else {
-					String issue = ThrowableUtils.getDescription(exception);
-					Log.severe(errorMsg + ": " + issue);
-				}
-
-				// Try again after a small delay:
-				if (retry) {
-					try {
-						Thread.sleep(SAVE_RETRY_DELAY_MILLIS);
-					} catch (InterruptedException e) {
-						// Restore the interrupt status for anyone interested in it, but otherwise
-						// ignore the interrupt here, because we prefer to keep retrying to still
-						// save the data to disk after all:
-						Thread.currentThread().interrupt();
-					}
-				}
-			});
-			return true;
-		} catch (Exception e) {
-			Log.severe(
-					"Failed to log trades to the CSV trade log! Data might have been lost! :(",
-					e
-			);
-			return false;
-		}
-	}
-
 	/**
-	 * Writes the pending trades to disk.
+	 * {@inheritDoc}
 	 * <p>
-	 * Goals:
-	 * <ul>
-	 * <li>Reliably log all trades.
-	 * <li>Log trades in the order in which they occurred.
-	 * <li>Log trades atomically, i.e. not partially, intertwined, or duplicated (e.g. if we retry
-	 * failed log attempts).
-	 * </ul>
-	 * 
-	 * Measures:
+	 * Measures to achieve the implementation goals:
 	 * <ul>
 	 * <li>We write to the log files via a single thread only, and assume that no other processes
 	 * write to them (concurrent reads should not be an issue).
@@ -470,14 +158,11 @@ public class CsvTradeLogger implements TradeLogger {
 	 * of a write that is meant to be atomic (i.e. a trade that is being logged) to actually be
 	 * split across multiple writes to the underlying file, and then no longer be atomic.
 	 * </ul>
-	 * 
 	 * References regarding atomicity of file appends:
 	 * <ul>
 	 * <li>https://www.notthewizard.com/2014/06/17/are-files-appends-really-atomic/
 	 * <li>https://nblumhardt.com/2016/08/atomic-shared-log-file-writes/
 	 * </ul>
-	 * <p>
-	 * This may be invoked asynchronously.
 	 * <p>
 	 * Depending on their timestamps, the trades may need to be logged to different log files. This
 	 * writes all consecutive trades that need to be logged to the same log file, and then
@@ -485,10 +170,11 @@ public class CsvTradeLogger implements TradeLogger {
 	 * 
 	 * @param saveContext
 	 *            the save context
-	 * @throws IOException
+	 * @throws Exception
 	 *             if saving fails
 	 */
-	private void writeTradesToLogFile(SaveContext saveContext) throws IOException {
+	@Override
+	protected void writeTrades(SaveContext saveContext) throws Exception {
 		TradeRecord trade = saveContext.getNextUnsavedTrade();
 		if (trade == null) return; // There are no unsaved trades
 
@@ -600,7 +286,7 @@ public class CsvTradeLogger implements TradeLogger {
 
 		// Recursively log the remaining trades to their target log files:
 		if (saveContext.hasUnsavedTrades()) {
-			this.writeTradesToLogFile(saveContext);
+			this.writeTrades(saveContext);
 		}
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
@@ -46,8 +46,6 @@ public class SQLiteTradeLogger implements TradeLogger {
             + "result_item_metadata TEXT NOT NULL, "
             + "trade_count SMALLINT UNSIGNED NOT NULL"
             + ");";
-    private static final String CREATE_SHOP_OWNER_INDEX = "CREATE INDEX IF NOT EXISTS shop_owner_uuid_idx "
-            + "ON " + TABLE_NAME + " (shop_owner_uuid);";
     private static final String INSERT_TRADE = "INSERT INTO " + TABLE_NAME
             + "(time, "
             + "player_uuid, player_name, "
@@ -80,7 +78,6 @@ public class SQLiteTradeLogger implements TradeLogger {
         plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
             try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
                 statement.execute(CREATE_TABLE);
-                statement.execute(CREATE_SHOP_OWNER_INDEX);
                 tableCreated.set(true);
             } catch (SQLException e) {
                 Log.severe("Could not create trades table. Trades won't be logged.", e);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
@@ -9,7 +9,6 @@ import java.sql.Statement;
 import java.sql.Types;
 import java.time.Instant;
 import java.time.ZoneOffset;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.bukkit.plugin.Plugin;
@@ -17,13 +16,13 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.tradelog.TradeLogUtils;
 import com.nisovin.shopkeepers.tradelog.TradeLogger;
 import com.nisovin.shopkeepers.tradelog.data.PlayerRecord;
 import com.nisovin.shopkeepers.tradelog.data.ShopRecord;
 import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
 import com.nisovin.shopkeepers.util.java.Validate;
 import com.nisovin.shopkeepers.util.logging.Log;
-import com.nisovin.shopkeepers.util.yaml.YamlUtils;
 
 /**
  * Logs trades to an SQLite database.
@@ -176,17 +175,10 @@ public class SQLiteTradeLogger implements TradeLogger {
 		// TODO Actually: Await any currently in-progress async tasks.
 	}
 
-	/**
-	 * See
-	 * {@link com.nisovin.shopkeepers.tradelog.csv.CsvTradeLogger#getItemMetadata(UnmodifiableItemStack)}.
-	 */
 	private String getItemMetadata(UnmodifiableItemStack itemStack) {
 		assert itemStack != null;
-		if (Settings.logItemMetadata) return "";
+		if (Settings.logItemMetadata) return ""; // Disabled
 
-		Map<String, Object> itemData = itemStack.serialize();
-		itemData.remove("type");
-		itemData.remove("amount");
-		return YamlUtils.toCompactYaml(itemData);
+		return TradeLogUtils.getItemMetadata(itemStack);
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
@@ -1,0 +1,158 @@
+package com.nisovin.shopkeepers.tradelog.sqlite;
+
+import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
+import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.tradelog.TradeLogger;
+import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
+import com.nisovin.shopkeepers.util.java.Validate;
+import com.nisovin.shopkeepers.util.logging.Log;
+import com.nisovin.shopkeepers.util.yaml.YamlUtils;
+import org.bukkit.plugin.Plugin;
+
+import java.nio.file.Path;
+import java.sql.*;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+/**
+ * Logs trades to an SQLite database.
+ */
+public class SQLiteTradeLogger implements TradeLogger {
+
+    private static final String TRADE_LOGS_FOLDER = "trade-logs";
+    private static final String FILE_NAME = "trades.db";
+    private static final String TABLE_NAME = "trade";
+    private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+            + "time DATETIME NOT NULL, "
+            + "player_uuid CHARACTER(36) NOT NULL, "
+            + "player_name VARCHAR(16) NOT NULL, "
+            + "shop_uuid VARCHAR(36) NOT NULL, "
+            + "shop_type VARCHAR(32) NOT NULL, "
+            + "shop_world VARCHAR(30) NOT NULL, "
+            + "shop_x INTEGER NOT NULL, "
+            + "shop_y INTEGER NOT NULL, "
+            + "shop_z INTEGER NOT NULL, "
+            + "shop_owner_uuid CHARACTER(36), " // Shop owner can be null for admin shops
+            + "shop_owner_name VARCHAR(16), "
+            + "item_1_type VARCHAR(64) NOT NULL, "
+            + "item_1_amount TINYINT UNSIGNED NOT NULL, "
+            + "item_1_metadata TEXT NOT NULL, "
+            + "item_2_type VARCHAR(64), " // Second item is optional and thus can be null
+            + "item_2_amount TINYINT UNSIGNED, "
+            + "item_2_metadata TEXT, "
+            + "result_item_type VARCHAR(64) NOT NULL, "
+            + "result_item_amount TINYINT UNSIGNED NOT NULL, "
+            + "result_item_metadata TEXT NOT NULL, "
+            + "trade_count SMALLINT UNSIGNED NOT NULL"
+            + ");";
+    private static final String CREATE_SHOP_OWNER_INDEX = "CREATE INDEX IF NOT EXISTS shop_owner_uuid_idx "
+            + "ON " + TABLE_NAME + " (shop_owner_uuid);";
+    private static final String INSERT_TRADE = "INSERT INTO " + TABLE_NAME
+            + "(time, "
+            + "player_uuid, player_name, "
+            + "shop_uuid, shop_type, shop_world, shop_x, shop_y, shop_z, shop_owner_uuid, shop_owner_name, "
+            + "item_1_type, item_1_amount, item_1_metadata, "
+            + "item_2_type, item_2_amount, item_2_metadata, "
+            + "result_item_type, result_item_amount, result_item_metadata, "
+            + "trade_count) "
+            + "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+
+    private final String connectionURL;
+
+    private boolean tableCreated = false;
+
+    public SQLiteTradeLogger(Plugin plugin) {
+        Validate.notNull(plugin, "plugin is null");
+        Path tradeLogsFolder = plugin.getDataFolder().toPath().resolve(TRADE_LOGS_FOLDER);
+        this.connectionURL = "jdbc:sqlite:" + tradeLogsFolder.resolve(FILE_NAME);
+
+        tableCreated = createTable();
+    }
+
+    private Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(connectionURL);
+    }
+
+    private boolean createTable() {
+        try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
+            statement.execute(CREATE_TABLE);
+            statement.execute(CREATE_SHOP_OWNER_INDEX);
+        } catch (SQLException e) {
+            Log.severe("Could not create trades table. Trades won't be logged.", e);
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void logTrade(TradeRecord trade) {
+        if (!tableCreated) {
+            return;
+        }
+
+        try (Connection connection = getConnection();
+             PreparedStatement statement = connection.prepareStatement(INSERT_TRADE)) {
+            statement.setObject(1, trade.getTimestamp().atOffset(ZoneOffset.UTC)); // time (in UTC)
+
+            statement.setString(2, trade.getPlayer().getUniqueId().toString()); // player_uuid
+            statement.setString(3, trade.getPlayer().getName()); // player_name
+
+            statement.setString(4, trade.getShop().getUniqueId().toString()); // shop_uuid
+            statement.setString(5, trade.getShop().getTypeId()); // shop_type
+            statement.setString(6, trade.getShop().getWorldName()); // shop_world
+            statement.setInt(7, trade.getShop().getX()); // shop_x
+            statement.setInt(8, trade.getShop().getY()); // shop_y
+            statement.setInt(9, trade.getShop().getZ()); // shop_z
+
+            if (trade.getShop().getOwner() != null) {
+                statement.setString(10, trade.getShop().getOwner().getUniqueId().toString()); // shop_owner_uuid
+                statement.setString(11, trade.getShop().getOwner().getName()); // shop_owner_name
+            } else {
+                statement.setString(10, null); // shop_owner_uuid
+                statement.setString(11, null); // shop_owner_name
+            }
+
+            statement.setString(12, trade.getItem1().getType().name()); // item_1_type
+            statement.setInt(13, trade.getItem1().getAmount()); // item_1_amount
+            statement.setString(14, getItemMetadata(trade.getItem1())); // item_1_metadata
+
+            if (trade.getItem2() != null) {
+                statement.setString(15, trade.getItem2().getType().name()); // item_2_type
+                statement.setInt(16, trade.getItem2().getAmount()); // item_2_amount
+                statement.setString(17, this.getItemMetadata(trade.getItem2())); // item_2_metadata
+            } else {
+                statement.setString(15, null); // item_2_type
+                statement.setNull(16, Types.TINYINT); // item_2_amount
+                statement.setString(17, null); // item_2_metadata
+            }
+
+            statement.setString(18, trade.getResultItem().getType().name()); // result_item_type
+            statement.setInt(19, trade.getResultItem().getAmount()); // result_item_amount
+            statement.setString(20, getItemMetadata(trade.getResultItem())); // result_item_metadata
+
+            statement.setInt(21, trade.getTradeCount()); // trade_count
+            statement.execute();
+        } catch (SQLException e) {
+            Log.severe("Could not not log trade.", e);
+        }
+    }
+
+    @Override
+    public void flush() {
+        // We do not need this as each logTrade will commit
+    }
+
+    /**
+     * See {@link com.nisovin.shopkeepers.tradelog.csv.CsvTradeLogger#getItemMetadata(UnmodifiableItemStack)}.
+     */
+    private String getItemMetadata(UnmodifiableItemStack itemStack) {
+        assert itemStack != null;
+        if (Settings.logItemMetadata) return "";
+
+        Map<String, Object> itemData = itemStack.serialize();
+        itemData.remove("type");
+        itemData.remove("amount");
+        return YamlUtils.toCompactYaml(itemData);
+    }
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
@@ -59,7 +59,7 @@ public class SQLiteTradeLogger implements TradeLogger {
     private final Plugin plugin;
     private final String connectionURL;
 
-    private AtomicBoolean tableCreated = new AtomicBoolean(false);
+    private final AtomicBoolean tableCreated = new AtomicBoolean(false);
 
     public SQLiteTradeLogger(Plugin plugin) {
         Validate.notNull(plugin, "plugin is null");

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/SQLiteTradeLogger.java
@@ -1,160 +1,192 @@
 package com.nisovin.shopkeepers.tradelog.sqlite;
 
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Types;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.tradelog.TradeLogger;
+import com.nisovin.shopkeepers.tradelog.data.PlayerRecord;
+import com.nisovin.shopkeepers.tradelog.data.ShopRecord;
 import com.nisovin.shopkeepers.tradelog.data.TradeRecord;
 import com.nisovin.shopkeepers.util.java.Validate;
 import com.nisovin.shopkeepers.util.logging.Log;
 import com.nisovin.shopkeepers.util.yaml.YamlUtils;
-import org.bukkit.plugin.Plugin;
-
-import java.nio.file.Path;
-import java.sql.*;
-import java.time.ZoneOffset;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Logs trades to an SQLite database.
  */
 public class SQLiteTradeLogger implements TradeLogger {
 
-    private static final String TRADE_LOGS_FOLDER = "trade-logs";
-    private static final String FILE_NAME = "trades.db";
-    private static final String TABLE_NAME = "trade";
-    private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
-            + "time DATETIME NOT NULL, "
-            + "player_uuid CHARACTER(36) NOT NULL, "
-            + "player_name VARCHAR(16) NOT NULL, "
-            + "shop_uuid VARCHAR(36) NOT NULL, "
-            + "shop_type VARCHAR(32) NOT NULL, "
-            + "shop_world VARCHAR(30) NOT NULL, "
-            + "shop_x INTEGER NOT NULL, "
-            + "shop_y INTEGER NOT NULL, "
-            + "shop_z INTEGER NOT NULL, "
-            + "shop_owner_uuid CHARACTER(36), " // Shop owner can be null for admin shops
-            + "shop_owner_name VARCHAR(16), "
-            + "item_1_type VARCHAR(64) NOT NULL, "
-            + "item_1_amount TINYINT UNSIGNED NOT NULL, "
-            + "item_1_metadata TEXT NOT NULL, "
-            + "item_2_type VARCHAR(64), " // Second item is optional and thus can be null
-            + "item_2_amount TINYINT UNSIGNED, "
-            + "item_2_metadata TEXT, "
-            + "result_item_type VARCHAR(64) NOT NULL, "
-            + "result_item_amount TINYINT UNSIGNED NOT NULL, "
-            + "result_item_metadata TEXT NOT NULL, "
-            + "trade_count SMALLINT UNSIGNED NOT NULL"
-            + ");";
-    private static final String INSERT_TRADE = "INSERT INTO " + TABLE_NAME
-            + "(time, "
-            + "player_uuid, player_name, "
-            + "shop_uuid, shop_type, shop_world, shop_x, shop_y, shop_z, shop_owner_uuid, shop_owner_name, "
-            + "item_1_type, item_1_amount, item_1_metadata, "
-            + "item_2_type, item_2_amount, item_2_metadata, "
-            + "result_item_type, result_item_amount, result_item_metadata, "
-            + "trade_count) "
-            + "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+	private static final String TRADE_LOGS_FOLDER = "trade-logs";
+	private static final String FILE_NAME = "trades.db";
+	private static final String TABLE_NAME = "trade";
+	// TODO SQlite has no data types (only storage classes). Also, we should probably not make
+	// assumptions here, e.g. about the max world name length.
+	private static final String CREATE_TABLE = "CREATE TABLE IF NOT EXISTS " + TABLE_NAME + " ("
+			+ "time DATETIME NOT NULL, "
+			+ "player_uuid CHARACTER(36) NOT NULL, "
+			+ "player_name VARCHAR(16) NOT NULL, "
+			+ "shop_uuid VARCHAR(36) NOT NULL, "
+			+ "shop_type VARCHAR(32) NOT NULL, "
+			+ "shop_world VARCHAR(30), " // Null for virtual shops
+			+ "shop_x INTEGER NOT NULL, "
+			+ "shop_y INTEGER NOT NULL, "
+			+ "shop_z INTEGER NOT NULL, "
+			+ "shop_owner_uuid CHARACTER(36), " // Shop owner can be null for admin shops
+			+ "shop_owner_name VARCHAR(16), "
+			+ "item_1_type VARCHAR(64) NOT NULL, "
+			+ "item_1_amount TINYINT UNSIGNED NOT NULL, "
+			+ "item_1_metadata TEXT NOT NULL, "
+			+ "item_2_type VARCHAR(64), " // Second item is optional and thus can be null
+			+ "item_2_amount TINYINT UNSIGNED, "
+			+ "item_2_metadata TEXT, "
+			+ "result_item_type VARCHAR(64) NOT NULL, "
+			+ "result_item_amount TINYINT UNSIGNED NOT NULL, "
+			+ "result_item_metadata TEXT NOT NULL, "
+			+ "trade_count SMALLINT UNSIGNED NOT NULL"
+			+ ");";
+	private static final String INSERT_TRADE = "INSERT INTO " + TABLE_NAME
+			+ "(time, "
+			+ "player_uuid, player_name, "
+			+ "shop_uuid, shop_type, shop_world, shop_x, shop_y, shop_z, "
+			+ "shop_owner_uuid, shop_owner_name, "
+			+ "item_1_type, item_1_amount, item_1_metadata, "
+			+ "item_2_type, item_2_amount, item_2_metadata, "
+			+ "result_item_type, result_item_amount, result_item_metadata, "
+			+ "trade_count) "
+			+ "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 
-    private final Plugin plugin;
-    private final String connectionURL;
+	private final Plugin plugin;
+	private final String connectionURL;
 
-    private final AtomicBoolean tableCreated = new AtomicBoolean(false);
+	private final AtomicBoolean tableCreated = new AtomicBoolean(false);
 
-    public SQLiteTradeLogger(Plugin plugin) {
-        Validate.notNull(plugin, "plugin is null");
-        this.plugin = plugin;
-        Path tradeLogsFolder = plugin.getDataFolder().toPath().resolve(TRADE_LOGS_FOLDER);
-        this.connectionURL = "jdbc:sqlite:" + tradeLogsFolder.resolve(FILE_NAME);
+	public SQLiteTradeLogger(Plugin plugin) {
+		Validate.notNull(plugin, "plugin is null");
+		this.plugin = plugin;
+		Path tradeLogsFolder = plugin.getDataFolder().toPath().resolve(TRADE_LOGS_FOLDER);
+		this.connectionURL = "jdbc:sqlite:" + tradeLogsFolder.resolve(FILE_NAME);
 
-        createTable();
-    }
+		this.createTable();
+	}
 
-    private Connection getConnection() throws SQLException {
-        return DriverManager.getConnection(connectionURL);
-    }
+	private Connection getConnection() throws SQLException {
+		return DriverManager.getConnection(connectionURL);
+	}
 
-    private void createTable() {
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try (Connection connection = getConnection(); Statement statement = connection.createStatement()) {
-                statement.execute(CREATE_TABLE);
-                tableCreated.set(true);
-            } catch (SQLException e) {
-                Log.severe("Could not create trades table. Trades won't be logged.", e);
-            }
-        });
-    }
+	private void createTable() {
+		plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+			try (	Connection connection = getConnection();
+					Statement statement = connection.createStatement()) {
+				statement.execute(CREATE_TABLE);
+				tableCreated.set(true);
+			} catch (SQLException e) {
+				Log.severe("Could not create trades table. Trades won't be logged.", e);
+			}
+		});
+	}
 
-    @Override
-    public void logTrade(TradeRecord trade) {
-        if (!tableCreated.get()) {
-            return;
-        }
+	@Override
+	public void logTrade(TradeRecord trade) {
+		// TODO Batch the incoming trades and commit them once the setup is done.
+		if (!tableCreated.get()) {
+			return;
+		}
 
-        plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
-            try (Connection connection = getConnection();
-                 PreparedStatement statement = connection.prepareStatement(INSERT_TRADE)) {
-                statement.setObject(1, trade.getTimestamp().atOffset(ZoneOffset.UTC)); // time (in UTC)
+		// TODO Keep the connection open? Cache the PreparedStatement?
+		plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+			try (	Connection connection = this.getConnection();
+					PreparedStatement statement = connection.prepareStatement(INSERT_TRADE)) {
+				Instant timestamp = trade.getTimestamp();
+				PlayerRecord player = trade.getPlayer();
 
-                statement.setString(2, trade.getPlayer().getUniqueId().toString()); // player_uuid
-                statement.setString(3, trade.getPlayer().getName()); // player_name
+				ShopRecord shop = trade.getShop();
+				PlayerRecord shopOwner = shop.getOwner();
+				@Nullable String shopOwnerId = null;
+				@Nullable String shopOwnerName = null;
+				if (shopOwner != null) {
+					shopOwnerId = shopOwner.getUniqueId().toString();
+					shopOwnerName = shopOwner.getName();
+				}
 
-                statement.setString(4, trade.getShop().getUniqueId().toString()); // shop_uuid
-                statement.setString(5, trade.getShop().getTypeId()); // shop_type
-                statement.setString(6, trade.getShop().getWorldName()); // shop_world
-                statement.setInt(7, trade.getShop().getX()); // shop_x
-                statement.setInt(8, trade.getShop().getY()); // shop_y
-                statement.setInt(9, trade.getShop().getZ()); // shop_z
+				UnmodifiableItemStack resultItem = trade.getResultItem();
+				UnmodifiableItemStack item1 = trade.getItem1();
+				UnmodifiableItemStack item2 = trade.getItem2(); // Can be null
+				@Nullable String item2Type = null;
+				@Nullable Integer item2Amount = null;
+				@Nullable String item2Metadata = null;
+				if (item2 != null) {
+					item2Type = item2.getType().name();
+					item2Amount = item2.getAmount();
+					item2Metadata = this.getItemMetadata(item2);
+				}
 
-                if (trade.getShop().getOwner() != null) {
-                    statement.setString(10, trade.getShop().getOwner().getUniqueId().toString()); // shop_owner_uuid
-                    statement.setString(11, trade.getShop().getOwner().getName()); // shop_owner_name
-                } else {
-                    statement.setString(10, null); // shop_owner_uuid
-                    statement.setString(11, null); // shop_owner_name
-                }
+				// TODO Store as UTC timestamp instead of as OffsetDateTime
+				statement.setObject(1, timestamp.atOffset(ZoneOffset.UTC)); // Time in UTC
 
-                statement.setString(12, trade.getItem1().getType().name()); // item_1_type
-                statement.setInt(13, trade.getItem1().getAmount()); // item_1_amount
-                statement.setString(14, getItemMetadata(trade.getItem1())); // item_1_metadata
+				statement.setString(2, player.getUniqueId().toString()); // player_uuid
+				statement.setString(3, player.getName()); // player_name
 
-                if (trade.getItem2() != null) {
-                    statement.setString(15, trade.getItem2().getType().name()); // item_2_type
-                    statement.setInt(16, trade.getItem2().getAmount()); // item_2_amount
-                    statement.setString(17, this.getItemMetadata(trade.getItem2())); // item_2_metadata
-                } else {
-                    statement.setString(15, null); // item_2_type
-                    statement.setNull(16, Types.TINYINT); // item_2_amount
-                    statement.setString(17, null); // item_2_metadata
-                }
+				statement.setString(4, shop.getUniqueId().toString()); // shop_uuid
+				statement.setString(5, shop.getTypeId()); // shop_type
+				statement.setString(6, shop.getWorldName()); // shop_world
+				statement.setInt(7, shop.getX()); // shop_x
+				statement.setInt(8, shop.getY()); // shop_y
+				statement.setInt(9, shop.getZ()); // shop_z
 
-                statement.setString(18, trade.getResultItem().getType().name()); // result_item_type
-                statement.setInt(19, trade.getResultItem().getAmount()); // result_item_amount
-                statement.setString(20, getItemMetadata(trade.getResultItem())); // result_item_metadata
+				statement.setString(10, shopOwnerId); // shop_owner_uuid
+				statement.setString(11, shopOwnerName); // shop_owner_name
 
-                statement.setInt(21, trade.getTradeCount()); // trade_count
-                statement.execute();
-            } catch (SQLException e) {
-                Log.severe("Could not not log trade.", e);
-            }
-        });
-    }
+				statement.setString(12, item1.getType().name()); // item_1_type
+				statement.setInt(13, item1.getAmount()); // item_1_amount
+				statement.setString(14, this.getItemMetadata(item1)); // item_1_metadata
 
-    @Override
-    public void flush() {
-        // We do not need this as each logTrade will commit
-    }
+				statement.setString(15, item2Type); // item_2_type
+				statement.setObject(16, item2Amount, Types.TINYINT); // item_2_amount
+				statement.setString(17, item2Metadata); // item_2_metadata
 
-    /**
-     * See {@link com.nisovin.shopkeepers.tradelog.csv.CsvTradeLogger#getItemMetadata(UnmodifiableItemStack)}.
-     */
-    private String getItemMetadata(UnmodifiableItemStack itemStack) {
-        assert itemStack != null;
-        if (Settings.logItemMetadata) return "";
+				statement.setString(18, resultItem.getType().name()); // result_item_type
+				statement.setInt(19, resultItem.getAmount()); // result_item_amount
+				statement.setString(20, this.getItemMetadata(resultItem)); // result_item_metadata
 
-        Map<String, Object> itemData = itemStack.serialize();
-        itemData.remove("type");
-        itemData.remove("amount");
-        return YamlUtils.toCompactYaml(itemData);
-    }
+				statement.setInt(21, trade.getTradeCount()); // trade_count
+				statement.executeUpdate();
+			} catch (SQLException e) {
+				Log.severe("Could not not log trade.", e);
+			}
+		});
+	}
+
+	@Override
+	public void flush() {
+		// Not needed: We commit all trades immediately.
+		// TODO Actually: Await any currently in-progress async tasks.
+	}
+
+	/**
+	 * See
+	 * {@link com.nisovin.shopkeepers.tradelog.csv.CsvTradeLogger#getItemMetadata(UnmodifiableItemStack)}.
+	 */
+	private String getItemMetadata(UnmodifiableItemStack itemStack) {
+		assert itemStack != null;
+		if (Settings.logItemMetadata) return "";
+
+		Map<String, Object> itemData = itemStack.serialize();
+		itemData.remove("type");
+		itemData.remove("amount");
+		return YamlUtils.toCompactYaml(itemData);
+	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/package-info.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/package-info.java
@@ -1,0 +1,2 @@
+@com.nisovin.shopkeepers.api.internal.util.annotations.NonNullByDefault
+package com.nisovin.shopkeepers.tradelog.sqlite;

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/package-info.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/tradelog/sqlite/package-info.java
@@ -1,2 +1,2 @@
-@com.nisovin.shopkeepers.api.internal.util.annotations.NonNullByDefault
+@org.eclipse.jdt.annotation.NonNullByDefault
 package com.nisovin.shopkeepers.tradelog.sqlite;

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/SingletonTask.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/SingletonTask.java
@@ -228,7 +228,7 @@ public abstract class SingletonTask {
 
 		// If an async execution is currently executing, acquiring the lock will wait for it to
 		// finish.
-		// If the async execution has not taken the lock yet, then its is either still pending to be
+		// If the async execution has not taken the lock yet, then it is either still pending to be
 		// started by the Scheduler on the main thread (which we are currently blocking), or it has
 		// already been started but not acquired the lock yet. In the latter case there may or may
 		// not already exist a worker thread for it, and it may or may not have checked its

--- a/modules/main/src/main/resources/config.yml
+++ b/modules/main/src/main/resources/config.yml
@@ -5,7 +5,7 @@
 # *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
 
 # Determines the required config migrations. Do not edit manually!
-config-version: 7
+config-version: 8
 # The initial debugging state of the plugin.
 debug: false
 # Additional debugging options.
@@ -695,8 +695,11 @@ trade-log-merge-duration-ticks: 300
 # reasons, the actual duration may dynamically vary by several ticks.
 trade-log-next-merge-timeout-ticks: 100
 
-# Whether to log all trades to CSV files inside the plugin folder.
-log-trades-to-csv: false
+# Which storage type to use to log trades to files inside the plugin folder.
+# '' disables this and logs nothing.
+# 'csv' logs all trades to CSV files, categorized by date.
+# 'sqlite' logs all trades to a SQLite database.
+trade-log-storage: ''
 
 # Whether to also log the metadata of items. This includes, for example, their
 # display name, lore, enchantments, etc. This data will be logged in Spigot's

--- a/modules/main/src/main/resources/config.yml
+++ b/modules/main/src/main/resources/config.yml
@@ -667,6 +667,12 @@ shop-owner-trade-notification-sound:
 # Trade Log
 # *~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*
 
+# The storage type to use for the trade log.
+# - 'DISABLED': Disables the logging of trades.
+# - 'SQLITE': Logs all trades to an SQLite database inside the plugin folder.
+# - 'CSV': Logs all trades to daily CSV files inside the plugin folder.
+trade-log-storage: 'DISABLED'
+
 # Players can trigger many equal trades in quick succession. For example, when
 # players trade by shift clicking the result slot, they can trigger up to 64
 # individual trades at once with a single click. And even when not shift
@@ -694,12 +700,6 @@ trade-log-merge-duration-ticks: 300
 # 'trade-log-merge-duration-ticks' effectively pointless. For performance
 # reasons, the actual duration may dynamically vary by several ticks.
 trade-log-next-merge-timeout-ticks: 100
-
-# Which storage type to use to log trades to files inside the plugin folder.
-# '' disables this and logs nothing.
-# 'csv' logs all trades to CSV files, categorized by date.
-# 'sqlite' logs all trades to a SQLite database.
-trade-log-storage: ''
 
 # Whether to also log the metadata of items. This includes, for example, their
 # display name, lore, enchantments, etc. This data will be logged in Spigot's


### PR DESCRIPTION
As outlined in #893 

- Adds a new SQLite implementing TradeLogger class
- Creates a table for trades with all fields that are also logged to the CSV file asynchronously
- logTrade inserts elements into the table directly, transactions and a flush for them are not required for this implementation (at least that's my opinion)
- Migrates config from `log-trades-to-csv` to `trade-log-storage` with `''` (or anything else) as default which disables logging, `'csv'` and `'sqlite'` to enable csv and sqlite logging respectively