### PR TITLE
fix(#901): change VillagerType/VillagerProffesion/FrogVariant/CatType enums to registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,9 @@
 Date format: (YYYY-MM-DD)  
 
 ## v2.22.3 (TBA)
-### Supported MC versions: (1.21,) 1.20.6, 1.20.4, 1.20.2, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5
+### Supported MC versions: 1.21, 1.20.6, 1.20.4, 1.20.2, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5
 
-**Update: Some change in Spigot 1.21 broke this version of the Shopkeepers plugin. This version only works on Spigot versions from before 2024-07-06.**
-
+* Fix: Compatibility with the latest versions of Spigot 1.21 (Thanks @DerMistkaefer). Spigot 1.21 builds from before 2024-07-07 are not supported.
 
 ## v2.22.2 (2024-07-20)
 ### Supported MC versions: (1.21,) 1.20.6, 1.20.4, 1.20.2, 1.20.1, 1.19.4, 1.18.2, 1.17.1, 1.16.5

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/commands/lib/arguments/ObjectByIdArgument.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/commands/lib/arguments/ObjectByIdArgument.java
@@ -2,7 +2,6 @@ package com.nisovin.shopkeepers.commands.lib.arguments;
 
 import java.util.List;
 
-import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -63,7 +62,8 @@ public abstract class ObjectByIdArgument<@NonNull I, @NonNull O>
 	// implementation to ObjectByIdArgument#getCompletionSuggestions(String), which should take this
 	// argument's object filter into account.
 	protected abstract ObjectIdArgument<I> createIdArgument(
-			@UnknownInitialization ObjectByIdArgument<I, O> this,
+			// TODO Eclipse (2024-06): Cannot add type annotation here (@UnknownInitialization)
+			ObjectByIdArgument<I, O> this,
 			String name,
 			IdArgumentArgs args
 	);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
@@ -1,11 +1,13 @@
 package com.nisovin.shopkeepers.compat.api;
 
-import org.bukkit.Keyed;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Registry;
 import org.bukkit.block.Sign;
-import org.bukkit.entity.*;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Wolf;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -16,13 +18,8 @@ import com.nisovin.shopkeepers.compat.CompatVersion;
 import com.nisovin.shopkeepers.compat.NMSManager;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
-import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
-
-import java.lang.reflect.Field;
 
 public interface NMSCallProvider {
 
@@ -79,7 +76,7 @@ public interface NMSCallProvider {
 	 * This mimics Minecraft's item comparison: This checks if the item stacks are either both
 	 * empty, or of same type and the provided item stack's metadata contains all the contents of
 	 * the required item stack's metadata (with any list metadata being equal).
-	 *
+	 * 
 	 * @param provided
 	 *            the provided item stack
 	 * @param required
@@ -160,34 +157,18 @@ public interface NMSCallProvider {
 		// Not supported by default.
 	}
 
-	// MC 1.20.3 specific features
-	// TODO Remove this once we only support MC 1.20.3 and above.
+	// MC 1.20.4 specific features
+	// TODO Remove this once we only support MC 1.20.4 and above.
+	// Cat registry was added in 1.20.4. Was an enum before that. Enum removed in 1.21.
 
-	public default DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		try {
-			// This is only supported on MC 1.20.3 and above. (for "compatibility mode")
-			Class<?> keyedType = Class.forName(Cat.Type.class.getName());
-			Class<?> registryClass = Class.forName(Registry.class.getName());
-			Field catVariantField = registryClass.getField("CAT_VARIANT");
-			Object catVariantRegistry = catVariantField.get(null);
-			return (DataSerializer<Cat.Type>) (Object) KeyedSerializers.forRegistry((Class<Keyed>)keyedType, (Registry<Keyed>) catVariantRegistry);
-		} catch (Throwable ex) {
-			// Not supported by default.
-			return null;
-		}
+	public default Cat.@Nullable Type getCatType(String typeName) {
+		// Not supported by default.
+		return null;
 	}
 
-	public default Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		try {
-			// This is only supported on MC 1.20.3 and above. (for "compatibility mode")
-			Class<?> registryClass = Class.forName(Registry.class.getName());
-			Field catVariantField = registryClass.getField("CAT_VARIANT");
-			Object catVariantRegistry = catVariantField.get(null);
-			return (Cat.Type) (Object) RegistryUtils.cycleKeyedConstant((Registry<Keyed>)catVariantRegistry, (Keyed) (Object) type, backwards);
-		} catch (Throwable ex) {
-			// Not supported by default.
-			return type;
-		}
+	public default String cycleCatType(String typeName, boolean backwards) {
+		// Not supported by default.
+		return typeName;
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
@@ -16,6 +16,7 @@ import com.nisovin.shopkeepers.compat.CompatVersion;
 import com.nisovin.shopkeepers.compat.NMSManager;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
+import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
 import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
 import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
@@ -177,8 +178,16 @@ public interface NMSCallProvider {
 	}
 
 	public default Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		// Not supported by default.
-		return type;
+		try {
+			// This is only supported on MC 1.20.3 and above. (for "compatibility mode")
+			Class<?> registryClass = Class.forName(Registry.class.getName());
+			Field catVariantField = registryClass.getField("CAT_VARIANT");
+			Object catVariantRegistry = catVariantField.get(null);
+			return (Cat.Type) (Object) RegistryUtils.cycleKeyedConstant((Registry<Keyed>)catVariantRegistry, (Keyed) (Object) type, backwards);
+		} catch (Throwable ex) {
+			// Not supported by default.
+			return type;
+		}
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/compat/api/NMSCallProvider.java
@@ -3,10 +3,7 @@ package com.nisovin.shopkeepers.compat.api;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Sign;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -17,7 +14,10 @@ import com.nisovin.shopkeepers.compat.CompatVersion;
 import com.nisovin.shopkeepers.compat.NMSManager;
 import com.nisovin.shopkeepers.util.annotations.ReadOnly;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
+import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
 
 public interface NMSCallProvider {
@@ -75,7 +75,7 @@ public interface NMSCallProvider {
 	 * This mimics Minecraft's item comparison: This checks if the item stacks are either both
 	 * empty, or of same type and the provided item stack's metadata contains all the contents of
 	 * the required item stack's metadata (with any list metadata being equal).
-	 * 
+	 *
 	 * @param provided
 	 *            the provided item stack
 	 * @param required
@@ -154,6 +154,19 @@ public interface NMSCallProvider {
 
 	public default void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		// Not supported by default.
+	}
+
+	// MC 1.20.3 specific features
+	// TODO Remove this once we only support MC 1.20.3 and above.
+
+	public default DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		// Not supported by default.
+		return null;
+	}
+
+	public default Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		// Not supported by default.
+		return type;
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/CatShop.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/CatShop.java
@@ -2,9 +2,7 @@ package com.nisovin.shopkeepers.shopobjects.living.types;
 
 import java.util.List;
 
-import org.bukkit.Color;
-import org.bukkit.DyeColor;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.entity.Cat;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -13,6 +11,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.api.shopkeeper.ShopCreationData;
+import com.nisovin.shopkeepers.compat.NMSManager;
 import com.nisovin.shopkeepers.lang.Messages;
 import com.nisovin.shopkeepers.shopkeeper.AbstractShopkeeper;
 import com.nisovin.shopkeepers.shopobjects.ShopObjectData;
@@ -31,20 +30,13 @@ import com.nisovin.shopkeepers.util.java.EnumUtils;
 
 public class CatShop extends SittableShop<@NonNull Cat> {
 
-	public static final Property<Cat.@NonNull Type> CAT_TYPE = new BasicProperty<Cat.@NonNull Type>()
-			.dataKeyAccessor("catType", EnumSerializers.lenient(Cat.Type.class))
-			.defaultValue(Cat.Type.TABBY)
-			.build();
-
 	public static final Property<@Nullable DyeColor> COLLAR_COLOR = new BasicProperty<@Nullable DyeColor>()
 			.dataKeyAccessor("collarColor", EnumSerializers.lenient(DyeColor.class))
 			.nullable() // Null indicates 'no collar' / untamed
 			.defaultValue(null)
 			.build();
 
-	private final PropertyValue<Cat.@NonNull Type> catTypeProperty = new PropertyValue<>(CAT_TYPE)
-			.onValueChanged(Unsafe.initialized(this)::applyCatType)
-			.build(properties);
+	private PropertyValue<Cat.@NonNull Type> catTypeProperty;
 	private final PropertyValue<@Nullable DyeColor> collarColorProperty = new PropertyValue<>(COLLAR_COLOR)
 			.onValueChanged(Unsafe.initialized(this)::applyCollarColor)
 			.build(properties);
@@ -61,6 +53,15 @@ public class CatShop extends SittableShop<@NonNull Cat> {
 	@Override
 	public void load(ShopObjectData shopObjectData) throws InvalidDataException {
 		super.load(shopObjectData);
+		if (catTypeProperty == null) {
+			Property<Cat.@NonNull Type> catType = new BasicProperty<Cat.@NonNull Type>()
+					.dataKeyAccessor("catType", NMSManager.getProvider().getCatTypeSerializer())
+					.defaultValue(Cat.Type.TABBY)
+					.build();
+			catTypeProperty = new PropertyValue<>(catType)
+					.onValueChanged(Unsafe.initialized(this)::applyCatType)
+					.build(properties);
+		}
 		catTypeProperty.load(shopObjectData);
 		collarColorProperty.load(shopObjectData);
 	}
@@ -98,7 +99,7 @@ public class CatShop extends SittableShop<@NonNull Cat> {
 	}
 
 	public void cycleCatType(boolean backwards) {
-		this.setCatType(EnumUtils.cycleEnumConstant(Cat.Type.class, this.getCatType(), backwards));
+		this.setCatType(NMSManager.getProvider().cycleCatType(this.getCatType(), backwards));
 	}
 
 	private void applyCatType() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/VillagerShop.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/VillagerShop.java
@@ -41,14 +41,18 @@ import com.nisovin.shopkeepers.util.java.MathUtils;
 
 public class VillagerShop extends BabyableShop<@NonNull Villager> {
 
-	private static final String DATA_KEY_PROFESSION = "profession";
+	private static final Registry<Villager.@NonNull Profession> REGISTRY_VILLAGER_PROFESSION
+			= Unsafe.castNonNull(Registry.VILLAGER_PROFESSION);
+	private static final Registry<Villager.@NonNull Type> REGISTRY_VILLAGER_TYPE
+			= Unsafe.castNonNull(Registry.VILLAGER_TYPE);
+
 	public static final Property<@NonNull Profession> PROFESSION = new BasicProperty<@NonNull Profession>()
-			.dataKeyAccessor(DATA_KEY_PROFESSION, KeyedSerializers.forRegistry(Profession.class, Registry.VILLAGER_PROFESSION))
+			.dataKeyAccessor("profession", KeyedSerializers.forRegistry(Profession.class, REGISTRY_VILLAGER_PROFESSION))
 			.defaultValue(Profession.NONE)
 			.build();
 
 	public static final Property<Villager.@NonNull Type> VILLAGER_TYPE = new BasicProperty<Villager.@NonNull Type>()
-			.dataKeyAccessor("villagerType", KeyedSerializers.forRegistry(Villager.Type.class, Registry.VILLAGER_TYPE))
+			.dataKeyAccessor("villagerType", KeyedSerializers.forRegistry(Villager.Type.class, REGISTRY_VILLAGER_TYPE))
 			.defaultValue(Villager.Type.PLAINS)
 			.build();
 
@@ -163,9 +167,11 @@ public class VillagerShop extends BabyableShop<@NonNull Villager> {
 	}
 
 	public void cycleProfession(boolean backwards) {
-		this.setProfession(
-				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, this.getProfession(), backwards)
-		);
+		this.setProfession(RegistryUtils.cycleKeyed(
+				REGISTRY_VILLAGER_PROFESSION,
+				this.getProfession(),
+				backwards
+		));
 	}
 
 	private void applyProfession() {
@@ -264,9 +270,11 @@ public class VillagerShop extends BabyableShop<@NonNull Villager> {
 	}
 
 	public void cycleVillagerType(boolean backwards) {
-		this.setVillagerType(
-				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_TYPE, this.getVillagerType(), backwards)
-		);
+		this.setVillagerType(RegistryUtils.cycleKeyed(
+				REGISTRY_VILLAGER_TYPE,
+				this.getVillagerType(),
+				backwards
+		));
 	}
 
 	private void applyVillagerType() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/VillagerShop.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/VillagerShop.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -27,27 +28,27 @@ import com.nisovin.shopkeepers.ui.editor.Button;
 import com.nisovin.shopkeepers.ui.editor.EditorSession;
 import com.nisovin.shopkeepers.ui.editor.ShopkeeperActionButton;
 import com.nisovin.shopkeepers.ui.trading.TradingHandler;
+import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
 import com.nisovin.shopkeepers.util.data.property.BasicProperty;
 import com.nisovin.shopkeepers.util.data.property.Property;
 import com.nisovin.shopkeepers.util.data.property.validation.java.IntegerValidators;
 import com.nisovin.shopkeepers.util.data.property.value.PropertyValue;
 import com.nisovin.shopkeepers.util.data.serialization.InvalidDataException;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
+import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.data.serialization.java.NumberSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
-import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.MathUtils;
 
 public class VillagerShop extends BabyableShop<@NonNull Villager> {
 
 	private static final String DATA_KEY_PROFESSION = "profession";
 	public static final Property<@NonNull Profession> PROFESSION = new BasicProperty<@NonNull Profession>()
-			.dataKeyAccessor(DATA_KEY_PROFESSION, EnumSerializers.lenient(Profession.class))
+			.dataKeyAccessor(DATA_KEY_PROFESSION, KeyedSerializers.forRegistry(Profession.class, Registry.VILLAGER_PROFESSION))
 			.defaultValue(Profession.NONE)
 			.build();
 
 	public static final Property<Villager.@NonNull Type> VILLAGER_TYPE = new BasicProperty<Villager.@NonNull Type>()
-			.dataKeyAccessor("villagerType", EnumSerializers.lenient(Villager.Type.class))
+			.dataKeyAccessor("villagerType", KeyedSerializers.forRegistry(Villager.Type.class, Registry.VILLAGER_TYPE))
 			.defaultValue(Villager.Type.PLAINS)
 			.build();
 
@@ -163,7 +164,7 @@ public class VillagerShop extends BabyableShop<@NonNull Villager> {
 
 	public void cycleProfession(boolean backwards) {
 		this.setProfession(
-				EnumUtils.cycleEnumConstant(Profession.class, this.getProfession(), backwards)
+				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, this.getProfession(), backwards)
 		);
 	}
 
@@ -264,7 +265,7 @@ public class VillagerShop extends BabyableShop<@NonNull Villager> {
 
 	public void cycleVillagerType(boolean backwards) {
 		this.setVillagerType(
-				EnumUtils.cycleEnumConstant(Villager.Type.class, this.getVillagerType(), backwards)
+				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_TYPE, this.getVillagerType(), backwards)
 		);
 	}
 

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/ZombieVillagerShop.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/ZombieVillagerShop.java
@@ -32,8 +32,11 @@ import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 
 public class ZombieVillagerShop extends ZombieShop<@NonNull ZombieVillager> {
 
+	private static final Registry<@NonNull Profession> REGISTRY_VILLAGER_PROFESSION
+			= Unsafe.castNonNull(Registry.VILLAGER_PROFESSION);
+
 	public static final Property<@NonNull Profession> PROFESSION = new BasicProperty<@NonNull Profession>()
-			.dataKeyAccessor("profession", KeyedSerializers.forRegistry(Profession.class, Registry.VILLAGER_PROFESSION))
+			.dataKeyAccessor("profession", KeyedSerializers.forRegistry(Profession.class, REGISTRY_VILLAGER_PROFESSION))
 			.defaultValue(Profession.NONE)
 			.build();
 
@@ -86,9 +89,11 @@ public class ZombieVillagerShop extends ZombieShop<@NonNull ZombieVillager> {
 	}
 
 	public void cycleProfession(boolean backwards) {
-		this.setProfession(
-				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, this.getProfession(), backwards)
-		);
+		this.setProfession(RegistryUtils.cycleKeyed(
+				REGISTRY_VILLAGER_PROFESSION,
+				this.getProfession(),
+				backwards
+		));
 	}
 
 	private void applyProfession() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/ZombieVillagerShop.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/living/types/ZombieVillagerShop.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.entity.Villager.Profession;
 import org.bukkit.entity.ZombieVillager;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -21,18 +22,18 @@ import com.nisovin.shopkeepers.shopobjects.living.SKLivingShopObjectType;
 import com.nisovin.shopkeepers.ui.editor.Button;
 import com.nisovin.shopkeepers.ui.editor.EditorSession;
 import com.nisovin.shopkeepers.ui.editor.ShopkeeperActionButton;
+import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
 import com.nisovin.shopkeepers.util.data.property.BasicProperty;
 import com.nisovin.shopkeepers.util.data.property.Property;
 import com.nisovin.shopkeepers.util.data.property.value.PropertyValue;
 import com.nisovin.shopkeepers.util.data.serialization.InvalidDataException;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
+import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
-import com.nisovin.shopkeepers.util.java.EnumUtils;
 
 public class ZombieVillagerShop extends ZombieShop<@NonNull ZombieVillager> {
 
 	public static final Property<@NonNull Profession> PROFESSION = new BasicProperty<@NonNull Profession>()
-			.dataKeyAccessor("profession", EnumSerializers.lenient(Profession.class))
+			.dataKeyAccessor("profession", KeyedSerializers.forRegistry(Profession.class, Registry.VILLAGER_PROFESSION))
 			.defaultValue(Profession.NONE)
 			.build();
 
@@ -86,7 +87,7 @@ public class ZombieVillagerShop extends ZombieShop<@NonNull ZombieVillager> {
 
 	public void cycleProfession(boolean backwards) {
 		this.setProfession(
-				EnumUtils.cycleEnumConstant(Profession.class, this.getProfession(), backwards)
+				RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, this.getProfession(), backwards)
 		);
 	}
 

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/ui/villager/editor/VillagerEditorHandler.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/ui/villager/editor/VillagerEditorHandler.java
@@ -2,7 +2,12 @@ package com.nisovin.shopkeepers.ui.villager.editor;
 
 import java.util.List;
 
-import org.bukkit.*;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.entity.AbstractVillager;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -54,6 +59,11 @@ import com.nisovin.shopkeepers.util.logging.Log;
  * An editor for regular villagers and wandering traders.
  */
 public final class VillagerEditorHandler extends AbstractEditorHandler {
+
+	private static final Registry<Villager.@NonNull Profession> REGISTRY_VILLAGER_PROFESSION
+			= Unsafe.castNonNull(Registry.VILLAGER_PROFESSION);
+	private static final Registry<Villager.@NonNull Type> REGISTRY_VILLAGER_TYPE
+			= Unsafe.castNonNull(Registry.VILLAGER_TYPE);
 
 	// We compare the recipes from the editor with the original recipes and keep the original
 	// recipes with their original internal data if the items have not changed.
@@ -561,7 +571,11 @@ public final class VillagerEditorHandler extends AbstractEditorHandler {
 				// replace the new trades with the old ones from the editor. But we try to preserve
 				// the old trades with their original data:
 				List<MerchantRecipe> previousRecipes = villager.getRecipes();
-				profession = RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, profession, backwards);
+				profession = RegistryUtils.cycleKeyed(
+						REGISTRY_VILLAGER_PROFESSION,
+						profession,
+						backwards
+				);
 				regularVillager.setProfession(profession);
 				// Restore previous trades with their original data:
 				villager.setRecipes(previousRecipes);
@@ -629,8 +643,8 @@ public final class VillagerEditorHandler extends AbstractEditorHandler {
 				}
 
 				boolean backwards = clickEvent.isRightClick();
-				villagerType = RegistryUtils.cycleKeyedConstant(
-						Registry.VILLAGER_TYPE,
+				villagerType = RegistryUtils.cycleKeyed(
+						REGISTRY_VILLAGER_TYPE,
 						villagerType,
 						backwards
 				);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/ui/villager/editor/VillagerEditorHandler.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/ui/villager/editor/VillagerEditorHandler.java
@@ -2,11 +2,7 @@ package com.nisovin.shopkeepers.ui.villager.editor;
 
 import java.util.List;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.DyeColor;
-import org.bukkit.Location;
-import org.bukkit.Material;
+import org.bukkit.*;
 import org.bukkit.entity.AbstractVillager;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.Player;
@@ -46,9 +42,9 @@ import com.nisovin.shopkeepers.ui.villager.VillagerUIHelper;
 import com.nisovin.shopkeepers.ui.villager.equipmentEditor.VillagerEquipmentEditorUI;
 import com.nisovin.shopkeepers.util.bukkit.MerchantUtils;
 import com.nisovin.shopkeepers.util.bukkit.PermissionUtils;
+import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
 import com.nisovin.shopkeepers.util.bukkit.TextUtils;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
-import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.MathUtils;
 import com.nisovin.shopkeepers.util.java.StringUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -565,7 +561,7 @@ public final class VillagerEditorHandler extends AbstractEditorHandler {
 				// replace the new trades with the old ones from the editor. But we try to preserve
 				// the old trades with their original data:
 				List<MerchantRecipe> previousRecipes = villager.getRecipes();
-				profession = EnumUtils.cycleEnumConstant(Profession.class, profession, backwards);
+				profession = RegistryUtils.cycleKeyedConstant(Registry.VILLAGER_PROFESSION, profession, backwards);
 				regularVillager.setProfession(profession);
 				// Restore previous trades with their original data:
 				villager.setRecipes(previousRecipes);
@@ -633,8 +629,8 @@ public final class VillagerEditorHandler extends AbstractEditorHandler {
 				}
 
 				boolean backwards = clickEvent.isRightClick();
-				villagerType = EnumUtils.cycleEnumConstant(
-						Villager.Type.class,
+				villagerType = RegistryUtils.cycleKeyedConstant(
+						Registry.VILLAGER_TYPE,
 						villagerType,
 						backwards
 				);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/RegistryUtils.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/RegistryUtils.java
@@ -4,13 +4,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Predicate;
 
-import com.google.common.collect.Lists;
-import com.nisovin.shopkeepers.util.java.CollectionUtils;
-import com.nisovin.shopkeepers.util.java.PredicateUtils;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.checkerframework.checker.nullness.qual.NonNull;
+
+import com.nisovin.shopkeepers.util.java.CollectionUtils;
+import com.nisovin.shopkeepers.util.java.PredicateUtils;
 
 public class RegistryUtils {
 
@@ -26,23 +26,24 @@ public class RegistryUtils {
 		return list;
 	}
 
-	public static <T extends @NonNull Keyed> @NonNull T cycleKeyedConstant(
+	public static <T extends @NonNull Keyed> @NonNull T cycleKeyed(
 			Registry<@NonNull T> registry,
 			@NonNull T current,
 			boolean backwards
 	) {
-		return cycleKeyedConstant(registry, current, backwards, PredicateUtils.alwaysTrue());
+		return cycleKeyed(registry, current, backwards, PredicateUtils.alwaysTrue());
 	}
 
 	// Cycled through all values but none got accepted: Returns current value.
-	public static <E extends @NonNull Keyed, T extends @NonNull E> T cycleKeyedConstant(
-			Registry<T> registry,
-			T current,
+	public static <T extends @NonNull Keyed> @NonNull T cycleKeyed(
+			Registry<@NonNull T> registry,
+			@NonNull T current,
 			boolean backwards,
-			Predicate<? super T> predicate
+			Predicate<? super @NonNull T> predicate
 	) {
-		List<@NonNull T> valuesList = Lists.newArrayList(registry.iterator());
-		return CollectionUtils.cycleValue(valuesList, false, current, backwards, predicate);
+		// TODO Cache the registry values?
+		List<@NonNull T> values = getValues(registry);
+		return CollectionUtils.cycleValue(values, current, backwards, predicate);
 	}
 
 	private RegistryUtils() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/RegistryUtils.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/util/bukkit/RegistryUtils.java
@@ -2,7 +2,11 @@ package com.nisovin.shopkeepers.util.bukkit;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Predicate;
 
+import com.google.common.collect.Lists;
+import com.nisovin.shopkeepers.util.java.CollectionUtils;
+import com.nisovin.shopkeepers.util.java.PredicateUtils;
 import org.bukkit.Keyed;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
@@ -20,6 +24,25 @@ public class RegistryUtils {
 		List<@NonNull NamespacedKey> list = new ArrayList<>();
 		registry.forEach(value -> list.add(value.getKey()));
 		return list;
+	}
+
+	public static <T extends @NonNull Keyed> @NonNull T cycleKeyedConstant(
+			Registry<@NonNull T> registry,
+			@NonNull T current,
+			boolean backwards
+	) {
+		return cycleKeyedConstant(registry, current, backwards, PredicateUtils.alwaysTrue());
+	}
+
+	// Cycled through all values but none got accepted: Returns current value.
+	public static <E extends @NonNull Keyed, T extends @NonNull E> T cycleKeyedConstant(
+			Registry<T> registry,
+			T current,
+			boolean backwards,
+			Predicate<? super T> predicate
+	) {
+		List<@NonNull T> valuesList = Lists.newArrayList(registry.iterator());
+		return CollectionUtils.cycleValue(valuesList, false, current, backwards, predicate);
 	}
 
 	private RegistryUtils() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/util/data/serialization/bukkit/NamespacedKeySerializers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/util/data/serialization/bukkit/NamespacedKeySerializers.java
@@ -4,6 +4,7 @@ import org.bukkit.NamespacedKey;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.nisovin.shopkeepers.util.bukkit.NamespacedKeyUtils;
 import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
 import com.nisovin.shopkeepers.util.data.serialization.InvalidDataException;
 import com.nisovin.shopkeepers.util.data.serialization.java.StringSerializers;
@@ -30,7 +31,7 @@ public final class NamespacedKeySerializers {
 		@Override
 		public NamespacedKey deserialize(Object data) throws InvalidDataException {
 			String keyString = StringSerializers.STRICT.deserialize(data);
-			@Nullable NamespacedKey key = NamespacedKey.fromString(keyString);
+			@Nullable NamespacedKey key = NamespacedKeyUtils.parse(keyString);
 			if (key == null) {
 				throw new InvalidDataException("Invalid namespaced key: '" + keyString + "'");
 			}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/util/data/serialization/bukkit/NamespacedKeySerializers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/util/data/serialization/bukkit/NamespacedKeySerializers.java
@@ -31,6 +31,8 @@ public final class NamespacedKeySerializers {
 		@Override
 		public NamespacedKey deserialize(Object data) throws InvalidDataException {
 			String keyString = StringSerializers.STRICT.deserialize(data);
+			// NamespacedKeyUtils.parse instead of NamespacedKey.fromString to also accept old
+			// uppercase enum names and interpret them as namespaced keys.
 			@Nullable NamespacedKey key = NamespacedKeyUtils.parse(keyString);
 			if (key == null) {
 				throw new InvalidDataException("Invalid namespaced key: '" + keyString + "'");

--- a/modules/v1_16_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_16_R3/NMSHandler.java
+++ b/modules/v1_16_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_16_R3/NMSHandler.java
@@ -13,22 +13,23 @@ import org.bukkit.craftbukkit.v1_16_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
-import com.nisovin.shopkeepers.util.java.Validate;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
+import com.nisovin.shopkeepers.util.java.Validate;
 import com.nisovin.shopkeepers.util.logging.Log;
 
 import net.minecraft.server.v1_16_R3.Entity;
@@ -263,12 +264,15 @@ public final class NMSHandler implements NMSCallProvider {
 	// Default implementation for MC 1.16+:
 
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
 	}
 }

--- a/modules/v1_16_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_16_R3/NMSHandler.java
+++ b/modules/v1_16_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_16_R3/NMSHandler.java
@@ -13,21 +13,22 @@ import org.bukkit.craftbukkit.v1_16_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_16_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_16_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
+import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.logging.Log;
 
 import net.minecraft.server.v1_16_R3.Entity;
@@ -257,5 +258,17 @@ public final class NMSHandler implements NMSCallProvider {
 		net.minecraft.server.v1_16_R3.Item nmsItem = CraftMagicNumbers.getItem(material);
 		if (nmsItem == null) return null;
 		return nmsItem.getName();
+	}
+
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 }

--- a/modules/v1_17_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_17_R2/NMSHandler.java
+++ b/modules/v1_17_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_17_R2/NMSHandler.java
@@ -14,19 +14,25 @@ import org.bukkit.craftbukkit.v1_17_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -255,13 +261,16 @@ public final class NMSHandler implements NMSCallProvider {
 	// Default implementation for MC 1.16+:
 
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_17_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_17_R2/NMSHandler.java
+++ b/modules/v1_17_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_17_R2/NMSHandler.java
@@ -14,24 +14,19 @@ import org.bukkit.craftbukkit.v1_17_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_17_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_17_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -255,6 +250,18 @@ public final class NMSHandler implements NMSCallProvider {
 		net.minecraft.world.item.Item nmsItem = CraftMagicNumbers.getItem(material);
 		if (nmsItem == null) return null;
 		return nmsItem.getDescriptionId();
+	}
+
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_18_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_18_R3/NMSHandler.java
+++ b/modules/v1_18_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_18_R3/NMSHandler.java
@@ -14,19 +14,25 @@ import org.bukkit.craftbukkit.v1_18_R2.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -255,13 +261,16 @@ public final class NMSHandler implements NMSCallProvider {
 	// Default implementation for MC 1.16+:
 
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_18_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_18_R3/NMSHandler.java
+++ b/modules/v1_18_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_18_R3/NMSHandler.java
@@ -14,24 +14,19 @@ import org.bukkit.craftbukkit.v1_18_R2.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_18_R2.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -255,6 +250,18 @@ public final class NMSHandler implements NMSCallProvider {
 		net.minecraft.world.item.Item nmsItem = CraftMagicNumbers.getItem(material);
 		if (nmsItem == null) return null;
 		return nmsItem.getDescriptionId();
+	}
+
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_19_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_19_R5/NMSHandler.java
+++ b/modules/v1_19_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_19_R5/NMSHandler.java
@@ -14,19 +14,26 @@ import org.bukkit.craftbukkit.v1_19_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -255,13 +262,16 @@ public final class NMSHandler implements NMSCallProvider {
 	// Default implementation for MC 1.16+:
 
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_19_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_19_R5/NMSHandler.java
+++ b/modules/v1_19_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_19_R5/NMSHandler.java
@@ -14,25 +14,19 @@ import org.bukkit.craftbukkit.v1_19_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_19_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_19_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
 import org.bukkit.inventory.MerchantInventory;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -256,6 +250,18 @@ public final class NMSHandler implements NMSCallProvider {
 		net.minecraft.world.item.Item nmsItem = CraftMagicNumbers.getItem(material);
 		if (nmsItem == null) return null;
 		return nmsItem.getDescriptionId();
+	}
+
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_20_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R2/NMSHandler.java
+++ b/modules/v1_20_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R2/NMSHandler.java
@@ -16,7 +16,17 @@ import org.bukkit.craftbukkit.v1_20_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -27,8 +37,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -257,13 +265,16 @@ public final class NMSHandler implements NMSCallProvider {
 	// Default implementation for MC 1.16+:
 
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_20_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R2/NMSHandler.java
+++ b/modules/v1_20_R2/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R2/NMSHandler.java
@@ -16,16 +16,7 @@ import org.bukkit.craftbukkit.v1_20_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -36,6 +27,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -259,6 +252,18 @@ public final class NMSHandler implements NMSCallProvider {
 		net.minecraft.world.item.Item nmsItem = CraftMagicNumbers.getItem(material);
 		if (nmsItem == null) return null;
 		return nmsItem.getDescriptionId();
+	}
+
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 
 	// MC 1.17 specific features

--- a/modules/v1_20_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R3/NMSHandler.java
+++ b/modules/v1_20_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R3/NMSHandler.java
@@ -16,7 +16,17 @@ import org.bukkit.craftbukkit.v1_20_R2.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R2.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -27,8 +37,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -254,6 +262,21 @@ public final class NMSHandler implements NMSCallProvider {
 		return nmsItem.getDescriptionId();
 	}
 
+	// Default implementation for MC 1.16+:
+
+	@Override
+	public Cat.@Nullable Type getCatType(String typeName) {
+		return EnumUtils.valueOf(Cat.Type.class, typeName);
+	}
+
+	@Override
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, catType, backwards).name();
+	}
+
 	// MC 1.17 specific features
 
 	@Override
@@ -327,17 +350,5 @@ public final class NMSHandler implements NMSCallProvider {
 	public void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		SignSide signSide = sign.getSide(Side.BACK);
 		signSide.setGlowingText(glowingText);
-	}
-
-	// MC 1.20.3 specific features
-
-	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return EnumSerializers.strict(Cat.Type.class);
-	}
-
-	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 }

--- a/modules/v1_20_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R3/NMSHandler.java
+++ b/modules/v1_20_R3/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R3/NMSHandler.java
@@ -16,16 +16,7 @@ import org.bukkit.craftbukkit.v1_20_R2.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R2.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R2.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -36,6 +27,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.java.EnumSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -334,5 +327,17 @@ public final class NMSHandler implements NMSCallProvider {
 	public void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		SignSide signSide = sign.getSide(Side.BACK);
 		signSide.setGlowingText(glowingText);
+	}
+
+	// MC 1.20.3 specific features
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return EnumSerializers.strict(Cat.Type.class);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return EnumUtils.cycleEnumConstant(Cat.Type.class, type, backwards);
 	}
 }

--- a/modules/v1_20_R4/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R4/NMSHandler.java
+++ b/modules/v1_20_R4/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R4/NMSHandler.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.Registry;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
@@ -17,7 +18,17 @@ import org.bukkit.craftbukkit.v1_20_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -28,9 +39,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.bukkit.NamespacedKeyUtils;
 import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -331,15 +341,22 @@ public final class NMSHandler implements NMSCallProvider {
 		signSide.setGlowingText(glowingText);
 	}
 
-	// MC 1.20.3 specific features
+	// MC 1.20.4 specific features
 
+	// Registry instead of enum.
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		@Nullable NamespacedKey key = NamespacedKeyUtils.parse(typeName);
+		if (key == null) return null; // Not recognized
+
+		return Registry.CAT_VARIANT.get(key); // Null if not found
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return RegistryUtils.cycleKeyed(Registry.CAT_VARIANT, catType, backwards).getKey().toString();
 	}
 }

--- a/modules/v1_20_R4/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R4/NMSHandler.java
+++ b/modules/v1_20_R4/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R4/NMSHandler.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 
 import org.bukkit.Material;
+import org.bukkit.Registry;
 import org.bukkit.block.Sign;
 import org.bukkit.block.sign.Side;
 import org.bukkit.block.sign.SignSide;
@@ -16,16 +17,7 @@ import org.bukkit.craftbukkit.v1_20_R3.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R3.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R3.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
+import org.bukkit.entity.*;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Merchant;
@@ -36,6 +28,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
+import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
 import com.nisovin.shopkeepers.util.java.Validate;
@@ -334,5 +329,17 @@ public final class NMSHandler implements NMSCallProvider {
 	public void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		SignSide signSide = sign.getSide(Side.BACK);
 		signSide.setGlowingText(glowingText);
+	}
+
+	// MC 1.20.3 specific features
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
 	}
 }

--- a/modules/v1_20_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R5/NMSHandler.java
+++ b/modules/v1_20_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R5/NMSHandler.java
@@ -18,7 +18,18 @@ import org.bukkit.craftbukkit.v1_20_R4.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Wolf.Variant;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -32,9 +43,8 @@ import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
+import com.nisovin.shopkeepers.util.bukkit.NamespacedKeyUtils;
 import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.CollectionUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
@@ -329,16 +339,23 @@ public final class NMSHandler implements NMSCallProvider {
 		signSide.setGlowingText(glowingText);
 	}
 
-	// MC 1.20.3 specific features
+	// MC 1.20.4 specific features
 
+	// Registry instead of enum.
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		@Nullable NamespacedKey key = NamespacedKeyUtils.parse(typeName);
+		if (key == null) return null; // Not recognized
+
+		return Registry.CAT_VARIANT.get(key); // Null if not found
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		return RegistryUtils.cycleKeyed(Registry.CAT_VARIANT, catType, backwards).getKey().toString();
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/v1_20_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R5/NMSHandler.java
+++ b/modules/v1_20_R5/src/main/java/com/nisovin/shopkeepers/compat/v1_20_R5/NMSHandler.java
@@ -18,17 +18,7 @@ import org.bukkit.craftbukkit.v1_20_R4.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_20_R4.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_20_R4.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.entity.Wolf.Variant;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -43,6 +33,8 @@ import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
 import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.CollectionUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
@@ -335,6 +327,18 @@ public final class NMSHandler implements NMSCallProvider {
 	public void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		SignSide signSide = sign.getSide(Side.BACK);
 		signSide.setGlowingText(glowingText);
+	}
+
+	// MC 1.20.3 specific features
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
+++ b/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
@@ -2,7 +2,6 @@ package com.nisovin.shopkeepers.compat.v1_21_R1;
 
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -19,7 +18,18 @@ import org.bukkit.craftbukkit.v1_21_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AbstractVillager;
+import org.bukkit.entity.Axolotl;
+import org.bukkit.entity.Cat;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Frog;
+import org.bukkit.entity.GlowSquid;
+import org.bukkit.entity.Goat;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Villager;
+import org.bukkit.entity.Wolf;
 import org.bukkit.entity.Wolf.Variant;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -33,9 +43,8 @@ import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
+import com.nisovin.shopkeepers.util.bukkit.NamespacedKeyUtils;
 import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
-import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
-import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.CollectionUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
@@ -296,8 +305,11 @@ public final class NMSHandler implements NMSCallProvider {
 
 	@Override
 	public String cycleFrogVariant(String variantName, boolean backwards) {
-		Frog.Variant currentVariant = Objects.requireNonNull(Registry.FROG_VARIANT.get(NamespacedKey.minecraft(variantName)));
-		return RegistryUtils.cycleKeyedConstant(Registry.FROG_VARIANT, currentVariant, backwards).getKey().getKey();
+		Registry<Frog.@NonNull Variant> frogVariantRegistry = Unsafe.castNonNull(Registry.FROG_VARIANT);
+		Frog.@Nullable Variant currentVariant = Registry.FROG_VARIANT.get(NamespacedKey.minecraft(variantName));
+		if (currentVariant == null) return variantName; // Not found
+
+		return RegistryUtils.cycleKeyed(frogVariantRegistry, currentVariant, backwards).getKey().getKey();
 	}
 
 	@Override
@@ -327,16 +339,24 @@ public final class NMSHandler implements NMSCallProvider {
 		signSide.setGlowingText(glowingText);
 	}
 
-	// MC 1.20.3 specific features
+	// MC 1.20.4 specific features
 
+	// Registry instead of enum.
 	@Override
-	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
-		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	public Cat.@Nullable Type getCatType(String typeName) {
+		@Nullable NamespacedKey key = NamespacedKeyUtils.parse(typeName);
+		if (key == null) return null; // Not recognized
+
+		return Registry.CAT_VARIANT.get(key); // Null if not found
 	}
 
 	@Override
-	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
-		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
+	public String cycleCatType(String typeName, boolean backwards) {
+		Cat.@Nullable Type catType = this.getCatType(typeName);
+		if (catType == null) return typeName; // Current value not found
+
+		Registry<Cat.@NonNull Type> catTypeRegistry = Unsafe.castNonNull(Registry.CAT_VARIANT);
+		return RegistryUtils.cycleKeyed(catTypeRegistry, catType, backwards).getKey().toString();
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
+++ b/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
@@ -19,17 +19,7 @@ import org.bukkit.craftbukkit.v1_21_R1.entity.CraftVillager;
 import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.v1_21_R1.inventory.CraftMerchant;
 import org.bukkit.craftbukkit.v1_21_R1.util.CraftMagicNumbers;
-import org.bukkit.entity.AbstractVillager;
-import org.bukkit.entity.Axolotl;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Frog;
-import org.bukkit.entity.GlowSquid;
-import org.bukkit.entity.Goat;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Villager;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.entity.Wolf.Variant;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -44,6 +34,8 @@ import com.nisovin.shopkeepers.compat.api.NMSCallProvider;
 import com.nisovin.shopkeepers.shopobjects.living.LivingEntityAI;
 import com.nisovin.shopkeepers.util.annotations.ReadWrite;
 import com.nisovin.shopkeepers.util.bukkit.RegistryUtils;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
+import com.nisovin.shopkeepers.util.data.serialization.bukkit.KeyedSerializers;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.CollectionUtils;
 import com.nisovin.shopkeepers.util.java.EnumUtils;
@@ -333,6 +325,18 @@ public final class NMSHandler implements NMSCallProvider {
 	public void setSignBackGlowingText(Sign sign, boolean glowingText) {
 		SignSide signSide = sign.getSide(Side.BACK);
 		signSide.setGlowingText(glowingText);
+	}
+
+	// MC 1.20.3 specific features
+
+	@Override
+	public DataSerializer<Cat.@NonNull Type> getCatTypeSerializer() {
+		return KeyedSerializers.forRegistry(Cat.Type.class, Registry.CAT_VARIANT);
+	}
+
+	@Override
+	public Cat.Type cycleCatType(Cat.Type type, boolean backwards) {
+		return RegistryUtils.cycleKeyedConstant(Registry.CAT_VARIANT, type, backwards);
 	}
 
 	// MC 1.20.5 specific features

--- a/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
+++ b/modules/v1_21_R1/src/main/java/com/nisovin/shopkeepers/compat/v1_21_R1/NMSHandler.java
@@ -2,6 +2,7 @@ package com.nisovin.shopkeepers.compat.v1_21_R1;
 
 import java.lang.reflect.Field;
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -303,11 +304,8 @@ public final class NMSHandler implements NMSCallProvider {
 
 	@Override
 	public String cycleFrogVariant(String variantName, boolean backwards) {
-		return EnumUtils.cycleEnumConstant(
-				Frog.Variant.class,
-				Frog.Variant.valueOf(variantName),
-				backwards
-		).name();
+		Frog.Variant currentVariant = Objects.requireNonNull(Registry.FROG_VARIANT.get(NamespacedKey.minecraft(variantName)));
+		return RegistryUtils.cycleKeyedConstant(Registry.FROG_VARIANT, currentVariant, backwards).getKey().getKey();
 	}
 
 	@Override


### PR DESCRIPTION
fix #901 

2024-07-06: Spigot changed the (VillagerProfession / VillagerType / FrogVariant / CatType) Enum to a Keyed Type.
https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/commits/7983b966630a4224ff7a26e321d2369444d17978#src%2Fmain%2Fjava%2Forg%2Fbukkit%2Fentity%2FVillager.java

This change caused a startup error.

The VillagerProfession / VillagerType has been a Keyed Type since 2019-05-01, which predates the release of minecraft version 1.14.1. Therefore, all versions supported by Shopkeepers (>= 1.16.5) are compatible with this change.

The FrogVariant is Keyed since implementation. But I only changed it in the 1.21 nms.

Now for the complicated part: the CatType has been a Keyed Type since 2023-12-08, corresponding to Minecraft versions 1.20.3/1.20.4. Therefore, I implemented the necessary switch in the NMS modules to accommodate this change.

I easily updated the Serializer. The internal NamespacedKeySerializer checks if a namespace exists; otherwise, it defaults to "minecraft", so no further migration is needed.

Now the server boots without errors.





