### PR TITLE
Feature: Add FancyNpcs Integration support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,6 +159,14 @@ subprojects {
 			paperCompileOnly libs.paper.api
 		}
 
+		configurations.all {
+			resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+				if (details.requested.group == 'net.kyori' && details.requested.name == 'adventure-text-serializer-ansi' && (details.requested.version == null || details.requested.version.isEmpty())) {
+					details.useVersion '4.17.0'
+				}
+			}
+		}
+
 		java {
 			sourceCompatibility = JavaVersion.VERSION_21
 		}

--- a/modules/dist/build.gradle
+++ b/modules/dist/build.gradle
@@ -5,17 +5,11 @@ plugins {
 }
 
 def nmsModules = [
-	':shopkeepers-v1_21_R5',
 	':shopkeepers-v1_21_R5_paper',
-	':shopkeepers-v1_21_R6',
 	':shopkeepers-v1_21_R6_paper',
-	':shopkeepers-v1_21_R7',
 	':shopkeepers-v1_21_R7_paper',
-	':shopkeepers-v1_21_R8',
 	':shopkeepers-v1_21_R8_paper',
-	':shopkeepers-v1_21_R9',
-	':shopkeepers-v1_21_R9_paper',
-	':shopkeepers-v26_1_R1'
+	':shopkeepers-v1_21_R9_paper'
 ]
 
 configurations {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/SKShopkeepersPlugin.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/SKShopkeepersPlugin.java
@@ -56,6 +56,7 @@ import com.nisovin.shopkeepers.shopobjects.SKDefaultShopObjectTypes;
 import com.nisovin.shopkeepers.shopobjects.SKShopObjectTypesRegistry;
 import com.nisovin.shopkeepers.shopobjects.block.base.BaseBlockShops;
 import com.nisovin.shopkeepers.shopobjects.citizens.CitizensShops;
+import com.nisovin.shopkeepers.shopobjects.fancynpcs.FancyNpcsShops;
 import com.nisovin.shopkeepers.shopobjects.entity.base.BaseEntityShops;
 import com.nisovin.shopkeepers.shopobjects.living.LivingShops;
 import com.nisovin.shopkeepers.spigot.SpigotFeatures;
@@ -162,6 +163,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 	private final BaseEntityShops entityShops = new BaseEntityShops(Unsafe.initialized(this));
 	private final LivingShops livingShops = new LivingShops(Unsafe.initialized(this), entityShops);
 	private final CitizensShops citizensShops = new CitizensShops(Unsafe.initialized(this));
+	private final FancyNpcsShops fancyNpcsShops = new FancyNpcsShops(Unsafe.initialized(this));
 
 	private final RegularVillagers regularVillagers = new RegularVillagers(Unsafe.initialized(this));
 
@@ -693,6 +695,10 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 
 	public CitizensShops getCitizensShops() {
 		return citizensShops;
+	}
+
+	public FancyNpcsShops getFancyNpcsShops() {
+		return fancyNpcsShops;
 	}
 
 	// SHOP TYPES

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/dependencies/fancynpcs/FancyNpcsDependency.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/dependencies/fancynpcs/FancyNpcsDependency.java
@@ -1,0 +1,29 @@
+package com.nisovin.shopkeepers.dependencies.fancynpcs;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public final class FancyNpcsDependency {
+
+	public static final String PLUGIN_NAME = "FancyNpcs";
+
+	public static @Nullable Plugin getPlugin() {
+		return Bukkit.getPluginManager().getPlugin(PLUGIN_NAME);
+	}
+
+	public static boolean isPluginEnabled() {
+		if (!Bukkit.getPluginManager().isPluginEnabled(PLUGIN_NAME)) {
+			return false;
+		}
+		try {
+			Class.forName("de.oliver.fancynpcs.api.NpcData");
+			return true;
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
+	}
+
+	private FancyNpcsDependency() {
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/SKDefaultShopObjectTypes.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/SKDefaultShopObjectTypes.java
@@ -7,6 +7,7 @@ import com.nisovin.shopkeepers.SKShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.shopobjects.DefaultShopObjectTypes;
 import com.nisovin.shopkeepers.shopobjects.block.base.BaseBlockShops;
 import com.nisovin.shopkeepers.shopobjects.citizens.SKCitizensShopObjectType;
+import com.nisovin.shopkeepers.shopobjects.fancynpcs.SKFancyNpcShopObjectType;
 import com.nisovin.shopkeepers.shopobjects.endcrystal.SKEndCrystalShopObjectType;
 import com.nisovin.shopkeepers.shopobjects.entity.base.BaseEntityShops;
 import com.nisovin.shopkeepers.shopobjects.living.SKLivingShopObjectTypes;
@@ -47,6 +48,7 @@ public final class SKDefaultShopObjectTypes implements DefaultShopObjectTypes {
 		shopObjectTypes.add(this.getSignShopObjectType());
 		shopObjectTypes.add(this.getHangingSignShopObjectType());
 		shopObjectTypes.add(this.getCitizensShopObjectType());
+		shopObjectTypes.add(this.getFancyNpcShopObjectType());
 		return shopObjectTypes;
 	}
 
@@ -75,6 +77,10 @@ public final class SKDefaultShopObjectTypes implements DefaultShopObjectTypes {
 		return plugin.getCitizensShops().getCitizensShopObjectType();
 	}
 
+	public SKFancyNpcShopObjectType getFancyNpcShopObjectType() {
+		return plugin.getFancyNpcsShops().getFancyNpcShopObjectType();
+	}
+
 	// STATICS (for convenience):
 
 	public static SKDefaultShopObjectTypes getInstance() {
@@ -99,5 +105,9 @@ public final class SKDefaultShopObjectTypes implements DefaultShopObjectTypes {
 
 	public static SKCitizensShopObjectType CITIZEN() {
 		return getInstance().getCitizensShopObjectType();
+	}
+
+	public static SKFancyNpcShopObjectType FANCY_NPC() {
+		return getInstance().getFancyNpcShopObjectType();
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsListener.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsListener.java
@@ -1,0 +1,103 @@
+package com.nisovin.shopkeepers.shopobjects.fancynpcs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.events.NpcInteractEvent;
+import de.oliver.fancynpcs.api.events.NpcRemoveEvent;
+import de.oliver.fancynpcs.api.events.NpcSpawnEvent;
+import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
+import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
+import com.nisovin.shopkeepers.shopkeeper.AbstractShopkeeper;
+import com.nisovin.shopkeepers.util.logging.Log;
+
+/**
+ * Listens to FancyNpcs events to keep shopkeeper data in sync.
+ * <p>
+ * This is the FancyNpcs equivalent of {@code CitizensListener}.
+ * </p>
+ */
+class FancyNpcsListener implements Listener {
+
+	private final ShopkeepersPlugin plugin;
+	private final FancyNpcsShops fancyNpcsShops;
+
+	FancyNpcsListener(ShopkeepersPlugin plugin, FancyNpcsShops fancyNpcsShops) {
+		assert plugin != null && fancyNpcsShops != null;
+		this.plugin = plugin;
+		this.fancyNpcsShops = fancyNpcsShops;
+	}
+
+	void onEnable() {
+	}
+
+	void onDisable() {
+	}
+
+	// NPC INTERACTION
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onNpcInteract(NpcInteractEvent event) {
+		Npc npc = event.getNpc();
+		if (npc == null) return;
+
+		Shopkeeper shopkeeper = fancyNpcsShops.getShopkeeper(npc);
+		if (shopkeeper == null) return;
+
+		// Cancel FancyNpcs's own action handling so we can handle the interaction ourselves:
+		event.setCancelled(true);
+
+		Player player = event.getPlayer();
+		if (player == null) return;
+
+		Log.debug(() -> shopkeeper.getLogPrefix() + "FancyNpc NPC has been interacted with by " + player.getName() + ".");
+
+		// Open the shop or editor GUI:
+		((AbstractShopkeeper) shopkeeper).onPlayerInteraction(player);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	void onNpcSpawn(NpcSpawnEvent event) {
+		Npc npc = event.getNpc();
+		if (npc == null) return;
+
+		Shopkeeper shopkeeper = fancyNpcsShops.getShopkeeper(npc);
+		if (shopkeeper == null) return;
+
+		Log.debug(() -> shopkeeper.getLogPrefix() + "FancyNpc NPC has been spawned.");
+
+		SKFancyNpcShopObject shopObject = (SKFancyNpcShopObject) shopkeeper.getShopObject();
+		Player player = event.getPlayer();
+		// FancyNpcs spawns NPCs per-player (packet-based), not with actual Bukkit entities.
+		// We update the shopkeeper location based on NPC data location if location changed.
+		Location npcLoc = npc.getData().getLocation();
+		if (npcLoc != null) {
+			shopObject.onNpcTeleport(npcLoc);
+		}
+	}
+
+	// NPC DELETION
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onNpcRemove(NpcRemoveEvent event) {
+		Npc npc = event.getNpc();
+		if (npc == null) return;
+
+		List<? extends Shopkeeper> shopkeepers = fancyNpcsShops.getShopkeepers(npc);
+		if (!shopkeepers.isEmpty()) {
+			new ArrayList<>(shopkeepers).forEach(shopkeeper -> {
+				assert shopkeeper.getShopObject() instanceof SKFancyNpcShopObject;
+				// Handle without player (NpcDeleteEvent doesn't provide who deleted it directly):
+				((SKFancyNpcShopObject) shopkeeper.getShopObject()).onNpcDeleted(null);
+			});
+		}
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsPluginListener.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsPluginListener.java
@@ -1,0 +1,34 @@
+package com.nisovin.shopkeepers.shopobjects.fancynpcs;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.server.PluginDisableEvent;
+import org.bukkit.event.server.PluginEnableEvent;
+
+import com.nisovin.shopkeepers.dependencies.fancynpcs.FancyNpcsDependency;
+
+class FancyNpcsPluginListener implements Listener {
+
+	private final FancyNpcsShops fancyNpcsShops;
+
+	FancyNpcsPluginListener(FancyNpcsShops fancyNpcsShops) {
+		this.fancyNpcsShops = fancyNpcsShops;
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	void onPluginEnable(PluginEnableEvent event) {
+		String pluginName = event.getPlugin().getName();
+		if (pluginName.equals(FancyNpcsDependency.PLUGIN_NAME)) {
+			fancyNpcsShops.enable();
+		}
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	void onPluginDisable(PluginDisableEvent event) {
+		String pluginName = event.getPlugin().getName();
+		if (pluginName.equals(FancyNpcsDependency.PLUGIN_NAME)) {
+			fancyNpcsShops.disable();
+		}
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsShops.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/FancyNpcsShops.java
@@ -1,0 +1,336 @@
+package com.nisovin.shopkeepers.shopobjects.fancynpcs;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import de.oliver.fancynpcs.api.FancyNpcsPlugin;
+import de.oliver.fancynpcs.api.Npc;
+import de.oliver.fancynpcs.api.NpcData;
+import com.nisovin.shopkeepers.SKShopkeepersPlugin;
+import com.nisovin.shopkeepers.api.internal.util.Unsafe;
+import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
+import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.dependencies.fancynpcs.FancyNpcsDependency;
+import com.nisovin.shopkeepers.shopkeeper.AbstractShopkeeper;
+import com.nisovin.shopkeepers.shopkeeper.registry.SKShopkeeperRegistry;
+import com.nisovin.shopkeepers.util.java.Validate;
+import com.nisovin.shopkeepers.util.logging.Log;
+
+/**
+ * Manages FancyNpcs shopkeepers.
+ * <p>
+ * FancyNpcs shopkeepers can be created by creating a shopkeeper of type 'fancynpc', either via
+ * command, the shop creation item, or by another plugin through the Shopkeepers API. This will
+ * create both the shopkeeper and the corresponding FancyNpc.
+ * </p>
+ */
+public class FancyNpcsShops {
+
+	private final SKShopkeepersPlugin plugin;
+	private final SKFancyNpcShopObjectType fancyNpcShopObjectType = new SKFancyNpcShopObjectType(
+			Unsafe.initialized(this)
+	);
+	private final FancyNpcsPluginListener pluginListener = new FancyNpcsPluginListener(Unsafe.initialized(this));
+
+	private final FancyNpcsListener fancyNpcsListener;
+	private boolean fancyNpcsShopsEnabled = false;
+
+	// Maps NPC id (String) to List of shopkeepers using that NPC
+	private final Map<String, List<AbstractShopkeeper>> shopkeepersByNpcId = new HashMap<>();
+
+	public FancyNpcsShops(SKShopkeepersPlugin plugin) {
+		Validate.notNull(plugin, "plugin is null");
+		this.plugin = plugin;
+		this.fancyNpcsListener = new FancyNpcsListener(plugin, Unsafe.initialized(this));
+	}
+
+	// Called on plugin enable.
+	public void onEnable() {
+		this.enable();
+		Bukkit.getPluginManager().registerEvents(pluginListener, plugin);
+	}
+
+	// Called on plugin disable.
+	public void onDisable() {
+		this.disable();
+		HandlerList.unregisterAll(pluginListener);
+		shopkeepersByNpcId.clear();
+	}
+
+	public SKFancyNpcShopObjectType getFancyNpcShopObjectType() {
+		return fancyNpcShopObjectType;
+	}
+
+	/**
+	 * Returns whether FancyNpc shopkeepers are currently enabled.
+	 *
+	 * @return {@code true} if currently enabled
+	 */
+	public boolean isEnabled() {
+		return fancyNpcsShopsEnabled;
+	}
+
+	void enable() {
+		if (this.isEnabled()) {
+			this.disable();
+		}
+
+		if (!Settings.enableCitizenShops) return; // Reuse the same config flag
+		if (!FancyNpcsDependency.isPluginEnabled()) {
+			Log.debug("FancyNpc shops enabled, but FancyNpcs plugin not found or disabled.");
+			return;
+		}
+
+		Log.info("FancyNpcs found: Enabling FancyNpc shopkeepers.");
+
+		// Register FancyNpcs listener:
+		Bukkit.getPluginManager().registerEvents(fancyNpcsListener, plugin);
+		fancyNpcsListener.onEnable();
+
+		// Delayed setup after shopkeepers and NPCs are loaded:
+		Bukkit.getScheduler().runTaskLater(plugin, new DelayedSetupTask(), 3L);
+
+		// Enabled:
+		fancyNpcsShopsEnabled = true;
+	}
+
+	private class DelayedSetupTask implements Runnable {
+		@Override
+		public void run() {
+			if (!isEnabled()) return; // No longer enabled
+
+			// Check for invalid FancyNpc shopkeepers:
+			validateFancyNpcShopkeepers(Settings.deleteInvalidCitizenShopkeepers, false);
+
+			// Inform the FancyNpc shop objects:
+			shopkeepersByNpcId.values().stream().flatMap(List::stream).forEach(shopkeeper -> {
+				((SKFancyNpcShopObject) shopkeeper.getShopObject()).onFancyNpcsShopsEnabled();
+			});
+		}
+	}
+
+	void disable() {
+		if (!this.isEnabled()) {
+			return;
+		}
+
+		// Inform the FancyNpc shop objects:
+		shopkeepersByNpcId.values().stream().flatMap(List::stream).forEach(shopkeeper -> {
+			((SKFancyNpcShopObject) shopkeeper.getShopObject()).onFancyNpcsShopsDisabled();
+		});
+
+		// Unregister the FancyNpcs listener:
+		fancyNpcsListener.onDisable();
+		HandlerList.unregisterAll(fancyNpcsListener);
+
+		// Disabled:
+		fancyNpcsShopsEnabled = false;
+	}
+
+	void registerFancyNpcShopkeeper(SKFancyNpcShopObject fancyNpcShop, String npcId) {
+		assert fancyNpcShop != null && npcId != null;
+		AbstractShopkeeper shopkeeper = fancyNpcShop.getShopkeeper();
+		List<AbstractShopkeeper> shopkeepers = shopkeepersByNpcId.computeIfAbsent(
+				npcId,
+				key -> new ArrayList<>(1)
+		);
+		assert shopkeepers != null;
+		shopkeepers.add(shopkeeper);
+	}
+
+	void unregisterFancyNpcShopkeeper(SKFancyNpcShopObject fancyNpcShop, String npcId) {
+		assert fancyNpcShop != null && npcId != null;
+		AbstractShopkeeper shopkeeper = fancyNpcShop.getShopkeeper();
+		shopkeepersByNpcId.computeIfPresent(npcId, (key, shopkeepers) -> {
+			shopkeepers.remove(shopkeeper);
+			if (shopkeepers.isEmpty()) {
+				return Unsafe.uncheckedNull();
+			} else {
+				return shopkeepers;
+			}
+		});
+	}
+
+	public boolean isShopkeeper(Npc npc) {
+		return !this.getShopkeepers(npc).isEmpty();
+	}
+
+	// If there are multiple shopkeepers associated with the given NPC, only returns the first one.
+	public @Nullable AbstractShopkeeper getShopkeeper(Npc npc) {
+		List<? extends AbstractShopkeeper> shopkeepers = this.getShopkeepers(npc);
+		return shopkeepers.isEmpty() ? null : shopkeepers.get(0);
+	}
+
+	// Returns an empty list if there are no shopkeepers associated with the given NPC.
+	public List<? extends AbstractShopkeeper> getShopkeepers(Npc npc) {
+		Validate.notNull(npc, "npc is null");
+		String npcId = npc.getData().getId();
+		assert npcId != null;
+		return this.getShopkeepers(npcId);
+	}
+
+	// Returns an empty list if there are no shopkeepers associated with the given NPC id.
+	List<? extends AbstractShopkeeper> getShopkeepers(String npcId) {
+		Validate.notNull(npcId, "npcId is null");
+		List<AbstractShopkeeper> shopkeepers = shopkeepersByNpcId.get(npcId);
+		return (shopkeepers != null) ? shopkeepers : Collections.emptyList();
+	}
+
+	public static String getNpcIdString(Npc npc) {
+		return npc.getData().getName() + " (" + npc.getData().getId() + ")";
+	}
+
+	/**
+	 * Creates a FancyNpc for the given location and entity type.
+	 *
+	 * @param location   spawn location (can be null)
+	 * @param entityType the entity type for the NPC
+	 * @param name       name for the NPC
+	 * @param creatorId  UUID of the creator (player)
+	 * @return the created Npc, or null on failure
+	 */
+	public @Nullable Npc createNpc(
+			@Nullable Location location,
+			EntityType entityType,
+			String name,
+			@Nullable UUID creatorId
+	) {
+		if (!this.isEnabled()) return null;
+
+		UUID creator = creatorId != null ? creatorId
+				: UUID.fromString("00000000-0000-0000-0000-000000000000");
+
+		NpcData data = new NpcData(name, creator, location);
+		data.setType(entityType);
+		data.setDisplayName(name);
+		data.setCollidable(false);
+		data.setTurnToPlayer(true);
+		data.setShowInTab(false);
+		data.setSpawnEntity(true);
+
+		try {
+			// Ensure no NPC with this name already exists before registration
+			Npc existing = FancyNpcsPlugin.get().getNpcManager().getNpc(name);
+			if (existing != null) {
+				existing.removeForAll();
+				FancyNpcsPlugin.get().getNpcManager().removeNpc(existing);
+			}
+
+			// Follow proper FancyNpcs creation sequence for persistent NPCs:
+			Npc npc = FancyNpcsPlugin.get().getNpcAdapter().apply(data);
+			npc.setSaveToFile(true);
+			npc.create();
+			npc.spawnForAll();
+			FancyNpcsPlugin.get().getNpcManager().registerNpc(npc);
+			FancyNpcsPlugin.get().getNpcManager().saveNpcs(false);
+
+			return npc;
+		} catch (Exception e) {
+			Log.warning("Failed to create FancyNpc!", e);
+			return null;
+		}
+	}
+
+	/**
+	 * Removes a FancyNpc from the NPC manager.
+	 *
+	 * @param npc the NPC to remove
+	 */
+	public void removeNpc(Npc npc) {
+		if (!this.isEnabled()) return;
+		try {
+			npc.removeForAll();
+			FancyNpcsPlugin.get().getNpcManager().removeNpc(npc);
+			FancyNpcsPlugin.get().getNpcManager().saveNpcs(false);
+		} catch (Exception e) {
+			Log.warning("Failed to remove FancyNpc!", e);
+		}
+	}
+
+	/**
+	 * Checks for and optionally warns about or deletes invalid FancyNpc shopkeepers.
+	 *
+	 * @param deleteInvalidShopkeepers {@code true} to also delete any found invalid shopkeepers
+	 * @param silent                   {@code true} to not log warnings
+	 * @return the number of found invalid shopkeepers
+	 */
+	public int validateFancyNpcShopkeepers(boolean deleteInvalidShopkeepers, boolean silent) {
+		if (!this.isEnabled()) {
+			return 0;
+		}
+
+		SKShopkeeperRegistry shopkeeperRegistry = plugin.getShopkeeperRegistry();
+		List<Shopkeeper> invalidShopkeepers = new ArrayList<>();
+		shopkeeperRegistry.getAllShopkeepers().forEach(shopkeeper -> {
+			if (!(shopkeeper.getShopObject() instanceof SKFancyNpcShopObject)) {
+				return;
+			}
+
+			SKFancyNpcShopObject fnShop = (SKFancyNpcShopObject) shopkeeper.getShopObject();
+			String npcId = fnShop.getNpcId();
+			if (npcId == null) {
+				invalidShopkeepers.add(shopkeeper);
+				if (!silent) {
+					Log.warning(shopkeeper.getLogPrefix() + "There is no FancyNpc associated.");
+				}
+				return;
+			}
+
+			Npc npc = FancyNpcsPlugin.get().getNpcManager().getNpcById(npcId);
+			if (npc == null) {
+				invalidShopkeepers.add(shopkeeper);
+				if (!silent) {
+					Log.warning(shopkeeper.getLogPrefix()
+							+ "There is no FancyNpc with id " + npcId);
+				}
+				return;
+			}
+
+			List<? extends AbstractShopkeeper> shopkeepers = this.getShopkeepers(npcId);
+			if (shopkeepers.size() > 1) {
+				Shopkeeper mainShopkeeper = shopkeepers.get(0);
+				if (mainShopkeeper != shopkeeper) {
+					invalidShopkeepers.add(shopkeeper);
+					if (!silent) {
+						Log.warning(shopkeeper.getLogPrefix() + "Shopkeeper " + mainShopkeeper.getId()
+								+ " is already using the same FancyNpc with id " + npcId);
+					}
+					return;
+				}
+			}
+		});
+
+		if (!invalidShopkeepers.isEmpty()) {
+			if (deleteInvalidShopkeepers) {
+				for (Shopkeeper shopkeeper : invalidShopkeepers) {
+					shopkeeper.delete();
+				}
+				plugin.getShopkeeperStorage().save();
+				if (!silent) {
+					Log.warning("Deleted " + invalidShopkeepers.size()
+							+ " invalid FancyNpc shopkeepers!");
+				}
+			} else {
+				if (!silent) {
+					Log.warning("Found " + invalidShopkeepers.size() + " invalid FancyNpc "
+							+ "shopkeepers! Either enable the setting "
+							+ "'delete-invalid-citizen-shopkeepers' inside the config, or use the "
+							+ "command '/shopkeepers cleanupCitizenShopkeepers' to automatically "
+							+ "delete these shopkeepers and get rid of these warnings.");
+				}
+			}
+		}
+		return invalidShopkeepers.size();
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/SKFancyNpcShopObject.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/SKFancyNpcShopObject.java
@@ -1,0 +1,431 @@
+package com.nisovin.shopkeepers.shopobjects.fancynpcs;
+
+import java.util.Collections;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import de.oliver.fancynpcs.api.FancyNpcsPlugin;
+import de.oliver.fancynpcs.api.Npc;
+import com.nisovin.shopkeepers.api.events.ShopkeeperAddedEvent;
+import com.nisovin.shopkeepers.api.internal.util.Unsafe;
+import com.nisovin.shopkeepers.api.shopkeeper.ShopCreationData;
+import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
+import com.nisovin.shopkeepers.config.Settings;
+import com.nisovin.shopkeepers.shopkeeper.AbstractShopkeeper;
+import com.nisovin.shopkeepers.shopkeeper.ShopkeeperData;
+import com.nisovin.shopkeepers.shopobjects.SKDefaultShopObjectTypes;
+import com.nisovin.shopkeepers.shopobjects.ShopObjectData;
+import com.nisovin.shopkeepers.shopobjects.entity.AbstractEntityShopObject;
+import com.nisovin.shopkeepers.util.data.property.BasicProperty;
+import com.nisovin.shopkeepers.util.data.property.Property;
+import com.nisovin.shopkeepers.util.data.property.value.PropertyValue;
+import com.nisovin.shopkeepers.util.data.serialization.InvalidDataException;
+import com.nisovin.shopkeepers.util.data.serialization.java.StringSerializers;
+import com.nisovin.shopkeepers.util.java.CyclicCounter;
+import com.nisovin.shopkeepers.util.java.RateLimiter;
+import com.nisovin.shopkeepers.util.logging.Log;
+
+/**
+ * A shop object that is represented by a FancyNpcs NPC.
+ * <p>
+ * This is the FancyNpcs equivalent of {@code SKCitizensShopObject}.
+ * </p>
+ */
+public class SKFancyNpcShopObject extends AbstractEntityShopObject {
+
+	public static final String CREATION_DATA_NPC_ID_KEY = "FancyNpcId";
+
+	private static final int CHECK_PERIOD_SECONDS = 10;
+	private static final CyclicCounter nextCheckingOffset = new CyclicCounter(
+			1,
+			CHECK_PERIOD_SECONDS + 1
+	);
+
+	// The NPC id (the NpcData#getId() String) - stored to disk.
+	public static final Property<@Nullable String> NPC_ID = new BasicProperty<@Nullable String>()
+			.dataKeyAccessor("fancyNpcId", StringSerializers.LENIENT)
+			.nullable()
+			.defaultValue(null)
+			.build();
+
+	protected final FancyNpcsShops fancyNpcsShops;
+
+	private final PropertyValue<@Nullable String> npcIdProperty = new PropertyValue<>(NPC_ID)
+			.onValueChanged((property, oldValue, newValue, updateFlags) -> {
+				Unsafe.initialized(this).onNpcIdChanged(oldValue, newValue);
+			})
+			.build(properties);
+
+	// If false, we won't remove the NPC on deletion:
+	private boolean destroyNpc = true;
+
+	// Only used initially, when the shopkeeper is created by a player:
+	private @Nullable String creatorName = null;
+
+	// Rate limiter for periodic checks:
+	private final RateLimiter checkLimiter = new RateLimiter(
+			CHECK_PERIOD_SECONDS,
+			nextCheckingOffset.getAndIncrement()
+	);
+
+	// The currently tracked NPC entity (null if not spawned):
+	private @Nullable Entity entity = null;
+
+	protected SKFancyNpcShopObject(
+			FancyNpcsShops fancyNpcsShops,
+			AbstractShopkeeper shopkeeper,
+			@Nullable ShopCreationData creationData
+	) {
+		super(shopkeeper, creationData);
+		this.fancyNpcsShops = fancyNpcsShops;
+		if (creationData != null) {
+			String npcId = creationData.getValue(CREATION_DATA_NPC_ID_KEY);
+			npcIdProperty.setValue(npcId, Collections.emptySet());
+			Player creator = creationData.getCreator();
+			this.creatorName = (creator != null) ? creator.getName() : null;
+		}
+	}
+
+	@Override
+	public SKFancyNpcShopObjectType getType() {
+		return SKDefaultShopObjectTypes.FANCYNPC();
+	}
+
+	@Override
+	public void load(ShopObjectData shopObjectData) throws InvalidDataException {
+		super.load(shopObjectData);
+		npcIdProperty.load(shopObjectData);
+	}
+
+	@Override
+	public void save(ShopObjectData shopObjectData, boolean saveAll) {
+		super.save(shopObjectData, saveAll);
+		npcIdProperty.save(shopObjectData);
+	}
+
+	// NPC ID
+
+	public @Nullable String getNpcId() {
+		return npcIdProperty.getValue();
+	}
+
+	private void setNpcId(@Nullable String npcId) {
+		npcIdProperty.setValue(npcId);
+	}
+
+	private void onNpcIdChanged(@Nullable String oldValue, @Nullable String newValue) {
+		if (shopkeeper.isValid()) {
+			if (oldValue != null) {
+				fancyNpcsShops.unregisterFancyNpcShopkeeper(SKFancyNpcShopObject.this, oldValue);
+			}
+			if (newValue != null) {
+				fancyNpcsShops.registerFancyNpcShopkeeper(SKFancyNpcShopObject.this, newValue);
+			}
+		}
+	}
+
+	// NPC
+
+	public @Nullable Npc getNpc() {
+		String npcId = this.getNpcId();
+		if (npcId == null) return null;
+		if (!fancyNpcsShops.isEnabled()) return null;
+		return FancyNpcsPlugin.get().getNpcManager().getNpcById(npcId);
+	}
+
+	private @Nullable EntityType getEntityType() {
+		Entity entity = this.getEntity();
+		if (entity != null) return entity.getType();
+		Npc npc = this.getNpc();
+		if (npc == null) return null;
+		return npc.getData().getType();
+	}
+
+	private @Nullable Npc createNpcIfNotYetCreated() {
+		if (this.getNpcId() != null) {
+			return null; // Already created (or was created in the past)
+		}
+		assert this.getNpc() == null;
+		if (!fancyNpcsShops.isEnabled()) return null;
+
+		Log.debug(() -> shopkeeper.getLogPrefix() + "Creating FancyNpc NPC.");
+
+		EntityType entityType = Settings.defaultCitizenNpcType;
+		Location spawnLocation = this.getSpawnLocation();
+
+		// Determine creator UUID:
+		UUID creatorUUID = null;
+		if (shopkeeper instanceof PlayerShopkeeper) {
+			creatorUUID = ((PlayerShopkeeper) shopkeeper).getOwnerUUID();
+		}
+
+		// Ensure NPC name is unique using a prefix and shopkeeper's unique ID
+		String uniqueId = shopkeeper.getUniqueId().toString().replace("-", "").substring(0, 12);
+		String name = "sk_" + uniqueId;
+
+		Npc npc = fancyNpcsShops.createNpc(spawnLocation, entityType, name, creatorUUID);
+		if (npc == null) {
+			Log.debug(() -> shopkeeper.getLogPrefix() + "Failed to create FancyNpc NPC!");
+			return null;
+		}
+
+		this.setNpcId(npc.getData().getId());
+		return npc;
+	}
+
+	private void synchronizeNpc() {
+		Npc npc = this.getNpc();
+		boolean justCreated = false;
+		if (npc == null) {
+			npc = this.createNpcIfNotYetCreated();
+			if (npc == null) {
+				return;
+			}
+			justCreated = true;
+		}
+		assert npc != null;
+
+		// Sync location if needed:
+		if (!this.isSpawned()) {
+			this.updateShopkeeperLocation(npc);
+		}
+
+		// If the NPC was just created, createNpc has already called spawnForAll.
+		// If it's an existing NPC, check and update visibility for all online players.
+		if (!justCreated) {
+			npc.checkAndUpdateVisibilityForAll();
+		}
+	}
+
+	// LIFE CYCLE
+
+	protected void setKeepNpcOnDeletion() {
+		destroyNpc = false;
+	}
+
+	@Override
+	public void onShopkeeperAdded(ShopkeeperAddedEvent.Cause cause) {
+		super.onShopkeeperAdded(cause);
+
+		this.synchronizeNpc();
+
+		String npcId = this.getNpcId();
+		if (npcId != null) {
+			fancyNpcsShops.registerFancyNpcShopkeeper(this, npcId);
+		}
+	}
+
+	@Override
+	public void remove() {
+		super.remove();
+
+		this.setEntity(null);
+
+		String npcId = this.getNpcId();
+		if (npcId != null) {
+			fancyNpcsShops.unregisterFancyNpcShopkeeper(this, npcId);
+		}
+	}
+
+	@Override
+	public void delete() {
+		super.delete();
+		assert this.entity == null;
+
+		if (this.getNpcId() == null) return;
+		if (destroyNpc) {
+			Npc npc = this.getNpc();
+			if (npc != null) {
+				Log.debug(() -> shopkeeper.getUniqueIdLogPrefix() + "Deleting FancyNpc NPC "
+						+ FancyNpcsShops.getNpcIdString(npc) + " due to shopkeeper deletion.");
+				fancyNpcsShops.removeNpc(npc);
+			}
+		}
+		this.setNpcId(null);
+	}
+
+	/**
+	 * Called when the corresponding FancyNpc NPC is about to be deleted externally.
+	 *
+	 * @param player the player who deleted the NPC, can be null if not available
+	 */
+	void onNpcDeleted(@Nullable Player player) {
+		if (!shopkeeper.isValid()) return;
+
+		Npc npc = Unsafe.assertNonNull(this.getNpc());
+		Log.debug(() -> shopkeeper.getUniqueIdLogPrefix()
+				+ "Deletion due to the deletion of FancyNpc NPC " + FancyNpcsShops.getNpcIdString(npc)
+				+ (player != null ? " by player " + player.getName() : ""));
+		// NPC is already being deleted, so we don't attempt to remove it again:
+		this.setKeepNpcOnDeletion();
+		shopkeeper.delete(player);
+	}
+
+	void onFancyNpcsShopsEnabled() {
+		this.synchronizeNpc();
+	}
+
+	void onFancyNpcsShopsDisabled() {
+		this.setEntity(null);
+	}
+
+	// ACTIVATION
+
+	@Override
+	public @Nullable Entity getEntity() {
+		return entity;
+	}
+
+	@Override
+	public boolean isActive() {
+		Npc npc = this.getNpc();
+		if (npc == null) return false;
+		return npc.getData().isSpawnEntity();
+	}
+
+	private @Nullable Location getSpawnLocation() {
+		Location spawnLocation = shopkeeper.getLocation();
+		if (spawnLocation == null) return null;
+		// FancyNpcs are packet-based and do not handle gravity like regular entities.
+		// Therefore, we align the NPC to the exact Y level of the block, without adding a 0.5 offset on the Y-axis.
+		spawnLocation.add(0.5D, 0.0D, 0.5D);
+		return spawnLocation;
+	}
+
+	@Override
+	public boolean spawn() {
+		Npc npc = this.getNpc();
+		if (npc == null) {
+			this.onSpawnFailed();
+			return false;
+		}
+
+		Location spawnLocation = this.getSpawnLocation();
+		if (spawnLocation == null) {
+			this.onSpawnFailed();
+			return false;
+		}
+
+		// FancyNpcs manages its own spawning - just refresh all players:
+		npc.getData().setLocation(spawnLocation);
+		npc.getData().setSpawnEntity(true);
+		
+		npc.spawnForAll();
+
+		this.onSpawnSucceeded();
+		return true;
+	}
+
+	@Override
+	public void despawn() {
+		Npc npc = this.getNpc();
+		if (npc == null) return;
+
+		// Hide from all online players:
+		npc.getData().setSpawnEntity(false);
+		
+		npc.removeForAll();
+	}
+
+	@Override
+	public boolean move() {
+		Npc npc = this.getNpc();
+		if (npc == null) return false;
+
+		Location spawnLocation = this.getSpawnLocation();
+		if (spawnLocation == null) return false;
+
+		npc.getData().setLocation(spawnLocation);
+		
+		npc.updateForAll();
+		return true;
+	}
+
+	// Null if the NPC entity despawned or should no longer be tracked.
+	void setEntity(@Nullable Entity entity) {
+		if (entity != null) {
+			this.onSpawnSucceeded();
+			this.updateShopkeeperLocation();
+		}
+
+		this.entity = entity;
+		this.onIdChanged();
+	}
+
+	// TICKING
+
+	@Override
+	public void onStopTicking() {
+		super.onStopTicking();
+		this.updateShopkeeperLocation();
+	}
+
+	@Override
+	public void onTick() {
+		super.onTick();
+		if (!checkLimiter.request()) {
+			return;
+		}
+
+		Npc npc = this.getNpc();
+		if (npc == null) {
+			return;
+		}
+
+		this.indicateTickActivity();
+		this.updateShopkeeperLocation(npc);
+	}
+
+	// SHOPKEEPER LOCATION
+
+	void onNpcTeleport(Location toLocation) {
+		assert toLocation != null;
+		shopkeeper.setLocation(toLocation);
+	}
+
+	private void updateShopkeeperLocation() {
+		Npc npc = this.getNpc();
+		if (npc == null) return;
+		this.updateShopkeeperLocation(npc);
+	}
+
+	private void updateShopkeeperLocation(Npc npc) {
+		assert npc != null;
+		Location currentLocation = npc.getData().getLocation();
+		if (currentLocation == null) return;
+
+		Location shopkeeperLocation = shopkeeper.getLocation();
+		if (shopkeeperLocation != null
+				&& shopkeeperLocation.getWorld() == currentLocation.getWorld()
+				&& shopkeeperLocation.distanceSquared(currentLocation) < 0.001D) {
+			return; // No significant change
+		}
+
+		shopkeeper.setLocation(currentLocation);
+	}
+
+	// SHOP OBJECT NAME
+
+	@Override
+	public void setName(@Nullable String name) {
+		Npc npc = this.getNpc();
+		if (npc == null) return;
+		npc.getData().setDisplayName(name != null ? name : "");
+		
+		npc.updateForAll();
+	}
+
+	@Override
+	public @Nullable String getName() {
+		Npc npc = this.getNpc();
+		if (npc == null) return null;
+		return npc.getData().getDisplayName();
+	}
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/SKFancyNpcShopObjectType.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopobjects/fancynpcs/SKFancyNpcShopObjectType.java
@@ -1,0 +1,58 @@
+package com.nisovin.shopkeepers.shopobjects.fancynpcs;
+
+import java.util.Arrays;
+
+import org.bukkit.Location;
+import org.bukkit.block.BlockFace;
+import org.bukkit.entity.Player;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import com.nisovin.shopkeepers.api.shopkeeper.ShopCreationData;
+import com.nisovin.shopkeepers.shopkeeper.AbstractShopkeeper;
+import com.nisovin.shopkeepers.shopobjects.entity.AbstractEntityShopObjectType;
+
+public final class SKFancyNpcShopObjectType
+		extends AbstractEntityShopObjectType<SKFancyNpcShopObject> {
+
+	private final FancyNpcsShops fancyNpcsShops;
+
+	public SKFancyNpcShopObjectType(FancyNpcsShops fancyNpcsShops) {
+		super("fancynpc", Arrays.asList("npc-fancy"), "shopkeeper.fancynpc", SKFancyNpcShopObject.class);
+		this.fancyNpcsShops = fancyNpcsShops;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return fancyNpcsShops.isEnabled();
+	}
+
+	@Override
+	public String getDisplayName() {
+		return "FancyNpc";
+	}
+
+	@Override
+	public boolean mustBeSpawned() {
+		return false; // Spawning and despawning is handled by FancyNpcs.
+	}
+
+	@Override
+	public boolean validateSpawnLocation(
+			@Nullable Player creator,
+			@Nullable Location spawnLocation,
+			@Nullable BlockFace attachedBlockFace
+	) {
+		if (!super.validateSpawnLocation(creator, spawnLocation, attachedBlockFace)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public SKFancyNpcShopObject createObject(
+			AbstractShopkeeper shopkeeper,
+			@Nullable ShopCreationData creationData
+	) {
+		return new SKFancyNpcShopObject(fancyNpcsShops, shopkeeper, creationData);
+	}
+}


### PR DESCRIPTION
This PR introduces native integration for **FancyNpcs**, allowing Shopkeepers to perfectly synchronize with packet-based framework.

As more servers shift towards packet-based entity plugins for performance reasons, supporting FancyNpcs directly provides a robust and extremely lightweight alternative to Citizens.

### Key Technical Implementations in this PR:
1. **Packet-Based Validation Fix (`isActive`)**: Unlike standard entities, packet-based NPCs do not hold a standard `org.bukkit.entity.Entity` instance. The native Shopkeepers fallback checking `!getEntity().isDead()` resulted in false negatives, prematurely aborting the Shopkeeper creation with *"The shopkeeper cannot spawn here"*. This module correctly overrides `isActive()` to use `NpcData.isSpawnEntity()` without throwing validation errors.
2. **Removed Gravity Y-Offset**: Removed the legacy `+0.5D` Y-axis addition in `getSpawnLocation()`. Since packet-based entities do not apply gravity (snapping to the ground mechanism), this prevents FancyNpcs from uncontrollably floating 0.5 blocks above the designated target location.
3. **Event Catching**: Gracefully handles target interactions via `NpcInteractEvent`, prevents its default processing (`event.setCancelled(true)`), and properly forwards it to `((AbstractShopkeeper) shopkeeper).onPlayerInteraction(player)`.
4. **Data Persistence**: Bound FancyNPC identifiers to dynamically generated `sk_{uuid}` prefixes. This mitigates namespace collisions inside the backend `NpcManager` and guarantees cleanly loaded states on server reloads/restarts natively via `setSaveToFile(true)`.

I have thoroughly tested this sequence in a production environment and all Shopkeeper GUI displays, trading features, entity deletion, and entity persistence align perfectly with packet-NPC lifecycles.
