### PR TITLE
Add shop members API and fix adventure-text-serializer-ansi version

### DIFF
--- a/modules/api/src/main/java/com/nisovin/shopkeepers/api/shopkeeper/player/MemberPermission.java
+++ b/modules/api/src/main/java/com/nisovin/shopkeepers/api/shopkeeper/player/MemberPermission.java
@@ -1,0 +1,26 @@
+package com.nisovin.shopkeepers.api.shopkeeper.player;
+
+/**
+ * Defines the permission level that shop members have.
+ * <p>
+ * This is configured server-wide and determines what members of a player shop
+ * can do.
+ */
+public enum MemberPermission {
+
+  /**
+   * Members can only access the shop's container (e.g. to restock items).
+   */
+  CHEST_ONLY,
+
+  /**
+   * Members can access the shop's container and edit trade offers.
+   */
+  CHEST_AND_TRADES,
+
+  /**
+   * Members have full co-owner rights, except they cannot delete the shop or
+   * manage memberships.
+   */
+  FULL;
+}

--- a/modules/api/src/main/java/com/nisovin/shopkeepers/api/shopkeeper/player/PlayerShopkeeper.java
+++ b/modules/api/src/main/java/com/nisovin/shopkeepers/api/shopkeeper/player/PlayerShopkeeper.java
@@ -1,5 +1,6 @@
 package com.nisovin.shopkeepers.api.shopkeeper.player;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.block.Block;
@@ -8,10 +9,12 @@ import org.bukkit.inventory.ItemStack;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
+import com.nisovin.shopkeepers.api.user.User;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 
 /**
- * A shopkeeper that is managed by a player. This shopkeeper draws its supplies from a container and
+ * A shopkeeper that is managed by a player. This shopkeeper draws its supplies
+ * from a container and
  * will deposit earnings back into that container.
  */
 public interface PlayerShopkeeper extends Shopkeeper {
@@ -20,7 +23,7 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * Sets the owner of this shop.
 	 * 
 	 * @param player
-	 *            the owner of this shop, not <code>null</code>
+	 *               the owner of this shop, not <code>null</code>
 	 */
 	public void setOwner(Player player);
 
@@ -28,9 +31,9 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * Sets the owner of this shop.
 	 * 
 	 * @param ownerUUID
-	 *            the owner's uuid, not <code>null</code>
+	 *                  the owner's uuid, not <code>null</code>
 	 * @param ownerName
-	 *            the owner's name, not <code>null</code> or empty
+	 *                  the owner's name, not <code>null</code> or empty
 	 */
 	public void setOwner(UUID ownerUUID, String ownerName);
 
@@ -61,7 +64,7 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * Checks if the given owner is owning this shop.
 	 * 
 	 * @param player
-	 *            the player to check
+	 *               the player to check
 	 * @return <code>true</code> if the given player owns this shop
 	 */
 	public boolean isOwner(Player player);
@@ -73,14 +76,77 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 */
 	public @Nullable Player getOwner();
 
+	// MEMBERS
+
+	/**
+	 * Adds a member to this shop.
+	 * 
+	 * @param memberUUID
+	 *                   the member's uuid, not <code>null</code>
+	 * @param memberName
+	 *                   the member's name, not <code>null</code> or empty
+	 * @return <code>true</code> if the member was added, <code>false</code> if the
+	 *         player is
+	 *         already a member or is the owner
+	 */
+	public boolean addMember(UUID memberUUID, String memberName);
+
+	/**
+	 * Removes a member from this shop.
+	 * 
+	 * @param memberUUID
+	 *                   the member's uuid, not <code>null</code>
+	 * @return <code>true</code> if the member was removed, <code>false</code> if
+	 *         the player was
+	 *         not a member
+	 */
+	public boolean removeMember(UUID memberUUID);
+
+	/**
+	 * Gets the members of this shop.
+	 * 
+	 * @return an unmodifiable list of members, not <code>null</code>
+	 */
+	public List<? extends User> getMembers();
+
+	/**
+	 * Checks if the given player is a member of this shop.
+	 * 
+	 * @param player
+	 *               the player to check
+	 * @return <code>true</code> if the given player is a member of this shop
+	 */
+	public boolean isMember(Player player);
+
+	/**
+	 * Checks if the given player uuid corresponds to a member of this shop.
+	 * 
+	 * @param playerUUID
+	 *                   the player's uuid to check
+	 * @return <code>true</code> if the given uuid is a member of this shop
+	 */
+	public boolean isMember(UUID playerUUID);
+
+	/**
+	 * Checks if the given player is the owner or a member of this shop.
+	 * 
+	 * @param player
+	 *               the player to check
+	 * @return <code>true</code> if the given player is the owner or a member
+	 */
+	public boolean isOwnerOrMember(Player player);
+
 	/**
 	 * Checks whether the shop owner is notified about trades of this shopkeeper.
 	 * <p>
-	 * This property only affects the trade notifications that are sent to the shop owner. It has no
-	 * effect on the general trade notifications that may be sent for this shopkeeper to other
+	 * This property only affects the trade notifications that are sent to the shop
+	 * owner. It has no
+	 * effect on the general trade notifications that may be sent for this
+	 * shopkeeper to other
 	 * players.
 	 * 
-	 * @return <code>true</code> if the shop owner is notified about trades of this shopkeeper
+	 * @return <code>true</code> if the shop owner is notified about trades of this
+	 *         shopkeeper
 	 */
 	public boolean isNotifyOnTrades();
 
@@ -88,7 +154,7 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * Sets whether the shop owner is notified about trades of this shopkeeper.
 	 * 
 	 * @param notifyOnTrades
-	 *            whether to notify the shop owner about trades
+	 *                       whether to notify the shop owner about trades
 	 * @see #isNotifyOnTrades()
 	 */
 	public void setNotifyOnTrades(boolean notifyOnTrades);
@@ -96,7 +162,8 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	/**
 	 * Checks whether this shopkeeper is for hire.
 	 * <p>
-	 * The shopkeeper is for hire if a {@link #getHireCost() hiring cost item} is set.
+	 * The shopkeeper is for hire if a {@link #getHireCost() hiring cost item} is
+	 * set.
 	 * 
 	 * @return <code>true</code> if this shopkeeper is for hire
 	 */
@@ -108,27 +175,31 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * The given item stack is copied before it is stored by the shopkeeper.
 	 * 
 	 * @param hireCost
-	 *            the hiring cost item, or <code>null</code> or empty to set this shopkeeper not for
-	 *            hire
+	 *                 the hiring cost item, or <code>null</code> or empty to set
+	 *                 this shopkeeper not for
+	 *                 hire
 	 */
 	public void setForHire(@Nullable ItemStack hireCost);
 
 	/**
 	 * Sets this shopkeeper for hire using the given hiring cost item.
 	 * <p>
-	 * The given item stack is assumed to be immutable and therefore not copied before it is stored
+	 * The given item stack is assumed to be immutable and therefore not copied
+	 * before it is stored
 	 * by the shopkeeper.
 	 * 
 	 * @param hireCost
-	 *            the hiring cost item, or <code>null</code> or empty to set this shopkeeper not for
-	 *            hire
+	 *                 the hiring cost item, or <code>null</code> or empty to set
+	 *                 this shopkeeper not for
+	 *                 hire
 	 */
 	public void setForHire(@Nullable UnmodifiableItemStack hireCost);
 
 	/**
 	 * Gets the hiring cost item of this shopkeeper.
 	 * 
-	 * @return an unmodifiable view on the hiring cost item, or <code>null</code> if this shopkeeper
+	 * @return an unmodifiable view on the hiring cost item, or <code>null</code> if
+	 *         this shopkeeper
 	 *         is not for hire
 	 */
 	public @Nullable UnmodifiableItemStack getHireCost();
@@ -158,24 +229,27 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	 * Sets the container's coordinates.
 	 * 
 	 * @param containerX
-	 *            the container's x coordinate
+	 *                   the container's x coordinate
 	 * @param containerY
-	 *            the container's y coordinate
+	 *                   the container's y coordinate
 	 * @param containerZ
-	 *            the container's z coordinate
+	 *                   the container's z coordinate
 	 */
 	public void setContainer(int containerX, int containerY, int containerZ);
 
 	/**
 	 * Gets the block of the shop's container.
 	 * <p>
-	 * This does not necessarily have to be a chest, but could also be another type of supported
+	 * This does not necessarily have to be a chest, but could also be another type
+	 * of supported
 	 * shop container.
 	 * <p>
-	 * The block might not actually be a valid container type currently (for example if something
+	 * The block might not actually be a valid container type currently (for example
+	 * if something
 	 * has broken or changed the type of the block in the meantime).
 	 * 
-	 * @return the shop's container block, or <code>null</code> if the container's world is not
+	 * @return the shop's container block, or <code>null</code> if the container's
+	 *         world is not
 	 *         loaded currently
 	 */
 	public @Nullable Block getContainer();
@@ -192,21 +266,23 @@ public interface PlayerShopkeeper extends Shopkeeper {
 	// SHOPKEEPER UIs - shortcuts for common UI types:
 
 	/**
-	 * Attempts to open the hiring interface of this shopkeeper for the specified player.
+	 * Attempts to open the hiring interface of this shopkeeper for the specified
+	 * player.
 	 * <p>
 	 * Fails if this shopkeeper type does not support hiring (e.g. admin shops).
 	 * 
 	 * @param player
-	 *            the player
+	 *               the player
 	 * @return <code>true</code> if the interface was successfully opened
 	 */
 	public boolean openHireWindow(Player player);
 
 	/**
-	 * Attempts to open the container inventory of this shopkeeper for the specified player.
+	 * Attempts to open the container inventory of this shopkeeper for the specified
+	 * player.
 	 * 
 	 * @param player
-	 *            the player
+	 *               the player
 	 * @return <code>true</code> if the interface was successfully opened
 	 */
 	public boolean openContainerWindow(Player player);

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/SKShopkeepersPlugin.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/SKShopkeepersPlugin.java
@@ -43,6 +43,7 @@ import com.nisovin.shopkeepers.internals.SKApiInternals;
 import com.nisovin.shopkeepers.lang.Messages;
 import com.nisovin.shopkeepers.metrics.PluginMetrics;
 import com.nisovin.shopkeepers.moving.ShopkeeperMoving;
+import com.nisovin.shopkeepers.members.ShopkeeperMembers;
 import com.nisovin.shopkeepers.naming.ShopkeeperNaming;
 import com.nisovin.shopkeepers.playershops.PlayerShops;
 import com.nisovin.shopkeepers.shopcreation.ShopkeeperCreation;
@@ -83,9 +84,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 					"com.nisovin.shopkeepers.dependencies.worldguard.WorldGuardDependency$Internal",
 					"com.nisovin.shopkeepers.dependencies.citizens.CitizensUtils$Internal",
 					"com.nisovin.shopkeepers.shopobjects.citizens.CitizensShopkeeperTrait",
-					"com.nisovin.shopkeepers.spigot.text.SpigotText$Internal"
-			))
-	);
+					"com.nisovin.shopkeepers.spigot.text.SpigotText$Internal")));
 
 	private static final int ASYNC_TASKS_TIMEOUT_SECONDS = 10;
 
@@ -119,13 +118,11 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 
 	// Shopkeeper registry:
 	private final SKShopkeeperRegistry shopkeeperRegistry = new SKShopkeeperRegistry(
-			Unsafe.initialized(this)
-	);
+			Unsafe.initialized(this));
 
 	// Shopkeeper storage:
 	private final SKShopkeeperStorage shopkeeperStorage = new SKShopkeeperStorage(
-			Unsafe.initialized(this)
-	);
+			Unsafe.initialized(this));
 
 	private final Commands commands = new Commands(Unsafe.initialized(this));
 	private final ChatInput chatInput = new ChatInput(Unsafe.initialized(this));
@@ -134,29 +131,25 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 	private final CommandTrading commandTrading = new CommandTrading(Unsafe.initialized(this));
 	private final TradeLoggers tradeLoggers = new TradeLoggers(Unsafe.initialized(this));
 	private final TradeNotifications tradeNotifications = new TradeNotifications(
-			Unsafe.initialized(this)
-	);
+			Unsafe.initialized(this));
 	private final EventDebugger eventDebugger = new EventDebugger(Unsafe.initialized(this));
 
 	private final PlayerShops playerShops = new PlayerShops(Unsafe.initialized(this));
 
 	private final ProtectedContainers protectedContainers = new ProtectedContainers(
-			Unsafe.initialized(this)
-	);
+			Unsafe.initialized(this));
 	private final ShopkeeperCreation shopkeeperCreation = new ShopkeeperCreation(
 			Unsafe.initialized(this),
 			shopkeeperRegistry,
-			protectedContainers
-	);
+			protectedContainers);
 	private final ShopkeeperNaming shopkeeperNaming = new ShopkeeperNaming(chatInput);
+	private final ShopkeeperMembers shopkeeperMembers = new ShopkeeperMembers(chatInput);
 	private final ShopkeeperMoving shopkeeperMoving = new ShopkeeperMoving(
 			interactionInput,
-			shopkeeperCreation.getShopkeeperPlacement()
-	);
+			shopkeeperCreation.getShopkeeperPlacement());
 	private final RemoveShopOnContainerBreak removeShopOnContainerBreak = new RemoveShopOnContainerBreak(
 			Unsafe.initialized(this),
-			protectedContainers
-	);
+			protectedContainers);
 
 	private final BaseBlockShops blockShops = new BaseBlockShops(Unsafe.initialized(this));
 	private final BaseEntityShops entityShops = new BaseEntityShops(Unsafe.initialized(this));
@@ -170,8 +163,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 	private final SKDefaultShopObjectTypes defaultShopObjectTypes = new SKDefaultShopObjectTypes(
 			Unsafe.initialized(this),
 			blockShops,
-			entityShops
-	);
+			entityShops);
 
 	private final PluginMetrics pluginMetrics = new PluginMetrics(Unsafe.initialized(this));
 
@@ -202,16 +194,19 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 	private boolean isOutdatedServerVersion() {
 		// Validate that this server is running a minimum required version:
 		// Changed in late Bukkit 1.20.6 from 'false' -> 'true':
-		// On the CraftBukkit side, there have been further bug fixes related to item serialization
+		// On the CraftBukkit side, there have been further bug fixes related to item
+		// serialization
 		// after that.
 		return !EntityType.ITEM.isSpawnable();
-		/*try {
-			// Changed during MC 1.21 from enum to interface:
-			Class<?> clazz = Class.forName("org.bukkit.entity.Villager$Type");
-			return clazz.isEnum();
-		} catch (ClassNotFoundException e) {
-			return true;
-		}*/
+		/*
+		 * try {
+		 * // Changed during MC 1.21 from enum to interface:
+		 * Class<?> clazz = Class.forName("org.bukkit.entity.Villager$Type");
+		 * return clazz.isEnum();
+		 * } catch (ClassNotFoundException e) {
+		 * return true;
+		 * }
+		 */
 	}
 
 	private void registerDefaults() {
@@ -229,7 +224,8 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 	@Override
 	public void onLoad() {
 		Log.setLogger(this.getLogger()); // Set up logger early
-		// Setting plugin reference early, so it is also available for any code running here:
+		// Setting plugin reference early, so it is also available for any code running
+		// here:
 		plugin = this;
 		InternalShopkeepersAPI.enable(this);
 
@@ -239,7 +235,8 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 			return;
 		}
 
-		// Try to load the compat module: Returns false if neither a compatible compat provider nor
+		// Try to load the compat module: Returns false if neither a compatible compat
+		// provider nor
 		// the fallback provider could be loaded.
 		this.incompatibleServer = !Compat.load(this);
 		if (this.incompatibleServer) {
@@ -247,7 +244,8 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		}
 
 		// Load config:
-		// Note: The config loading can already depend on Compat functionality (e.g. for item
+		// Note: The config loading can already depend on Compat functionality (e.g. for
+		// item
 		// loading), so Compat must be initialized first.
 		this.configLoadError = Settings.loadConfig();
 		if (this.configLoadError != null) {
@@ -258,7 +256,8 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		Messages.loadLanguageFile();
 
 		// WorldGuard only allows registering flags before it gets enabled.
-		// Note: Changing the config setting has no effect until the next server restart or server
+		// Note: Changing the config setting has no effect until the next server restart
+		// or server
 		// reload.
 		if (Settings.registerWorldGuardAllowShopFlag) {
 			WorldGuardDependency.registerAllowShopFlag();
@@ -267,11 +266,15 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		// Register defaults:
 		this.registerDefaults();
 
-		// Load all plugin classes up front to ensure that we don't run into missing classes
-		// (usually during shutdown) when the plugin jar gets dynamically replaced during runtime
+		// Load all plugin classes up front to ensure that we don't run into missing
+		// classes
+		// (usually during shutdown) when the plugin jar gets dynamically replaced
+		// during runtime
 		// (e.g. for hot reloads):
-		// This must be done after the compatibility provider has been initialized, because some
-		// class initialization logic may already depend on it (e.g. to retrieve Bukkit registries).
+		// This must be done after the compatibility provider has been initialized,
+		// because some
+		// class initialization logic may already depend on it (e.g. to retrieve Bukkit
+		// registries).
 		this.loadAllPluginClasses();
 	}
 
@@ -356,12 +359,16 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		}
 
 		// Call startup event so that other plugins can make their registrations:
-		// TODO This event doesn't make much sense, because dependent plugins are enabled after us,
+		// TODO This event doesn't make much sense, because dependent plugins are
+		// enabled after us,
 		// so they were not yet able to register their event handlers.
-		// An option could be to enable the Shopkeepers plugin 1 tick after all other plugins have
-		// been enabled. But then any performance intensive startup tasks (loading shops, ..) would
+		// An option could be to enable the Shopkeepers plugin 1 tick after all other
+		// plugins have
+		// been enabled. But then any performance intensive startup tasks (loading
+		// shops, ..) would
 		// potentially be interpreted as lag by the server.
-		// Another option is for these plugins to perform their setup during onLoad (similar to how
+		// Another option is for these plugins to perform their setup during onLoad
+		// (similar to how
 		// we register default shop types, etc., during onLoad).
 		Bukkit.getPluginManager().callEvent(new ShopkeepersStartupEvent());
 
@@ -383,7 +390,8 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		// DEFAULT SHOP OBJECT TYPES
 
 		// Enable block shops:
-		// Note: This has to be enabled before the shop creation listener, so that interactions with
+		// Note: This has to be enabled before the shop creation listener, so that
+		// interactions with
 		// block shops take precedence over interactions with the shop creation item.
 		blockShops.onEnable();
 
@@ -411,6 +419,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 
 		// Enable shopkeeper naming and moving:
 		shopkeeperNaming.onEnable();
+		shopkeeperMembers.onEnable();
 		shopkeeperMoving.onEnable();
 
 		// Enable shopkeeper storage:
@@ -466,13 +475,13 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		SchedulerUtils.awaitAsyncTasksCompletion(
 				this,
 				ASYNC_TASKS_TIMEOUT_SECONDS,
-				this.getLogger()
-		);
+				this.getLogger());
 
 		// Disable UI system:
 		uiSystem.onDisable();
 
-		// Deactivate (despawn) all shopkeepers (prior to saving shopkeepers data and before
+		// Deactivate (despawn) all shopkeepers (prior to saving shopkeepers data and
+		// before
 		// unloading all shopkeepers):
 		shopkeeperRegistry.getChunkActivator().deactivateShopkeepersInAllWorlds();
 
@@ -510,6 +519,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		regularVillagers.onDisable();
 
 		shopkeeperNaming.onDisable();
+		shopkeeperMembers.onDisable();
 		shopkeeperMoving.onDisable();
 
 		shopkeeperCreation.onDisable();
@@ -725,6 +735,12 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 		return shopkeeperNaming;
 	}
 
+	// SHOPKEEPER MEMBERS
+
+	public ShopkeeperMembers getShopkeeperMembers() {
+		return shopkeeperMembers;
+	}
+
 	// SHOPKEEPER MOVING
 
 	public ShopkeeperMoving getShopkeeperMoving() {
@@ -753,8 +769,7 @@ public class SKShopkeepersPlugin extends JavaPlugin implements InternalShopkeepe
 
 	@Override
 	public @Nullable AbstractShopkeeper handleShopkeeperCreation(
-			ShopCreationData shopCreationData
-	) {
+			ShopCreationData shopCreationData) {
 		Validate.notNull(shopCreationData, "shopCreationData is null");
 		ShopType<?> rawShopType = shopCreationData.getShopType();
 		Validate.isTrue(rawShopType instanceof AbstractShopType,

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/config/Settings.java
@@ -23,6 +23,7 @@ import com.nisovin.shopkeepers.SKShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.events.UpdateItemEvent;
 import com.nisovin.shopkeepers.api.internal.util.Unsafe;
+import com.nisovin.shopkeepers.api.shopkeeper.player.MemberPermission;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 import com.nisovin.shopkeepers.config.lib.Config;
 import com.nisovin.shopkeepers.config.lib.ConfigData;
@@ -102,8 +103,7 @@ public class Settings extends Config {
 	public static ItemData shopCreationItem = new ItemData(
 			Material.VILLAGER_SPAWN_EGG,
 			"{\"text\":\"Shopkeeper\",\"italic\":false,\"color\":\"green\"}",
-			null
-	);
+			null);
 
 	public static boolean addShopCreationItemTag = true;
 	public static boolean identifyShopCreationItemByTag = true;
@@ -117,6 +117,9 @@ public class Settings extends Config {
 	public static int maxShopsPerPlayer = -1;
 	public static String maxShopsPermOptions = "5,15,25";
 
+	public static String memberPermissions = "FULL";
+	public static int maxMembersPerShop = 5;
+
 	public static boolean protectContainers = true;
 	public static boolean preventItemMovement = true;
 	public static boolean preventCopperGolemAccess = true;
@@ -127,7 +130,8 @@ public class Settings extends Config {
 	/*
 	 * Shop (Object) Types
 	 */
-	// Villager is the default and therefore first. The other entity types are alphabetically
+	// Villager is the default and therefore first. The other entity types are
+	// alphabetically
 	// sorted.
 	// TODO Generate the default enabled mobs list based on the server's version.
 	public static List<String> enabledLivingShops = CollectionUtils.addAll(
@@ -217,8 +221,7 @@ public class Settings extends Config {
 					"NAUTILUS", // MC 1.21.11
 					"PARCHED", // MC 1.21.11
 					"ZOMBIE_NAUTILUS" // MC 1.21.11
-			), String::compareTo)
-	);
+			), String::compareTo));
 
 	public static boolean enableEndCrystalShops = true;
 	public static boolean allowEndCrystalShopsInTheEnd = false;
@@ -226,11 +229,14 @@ public class Settings extends Config {
 	public static boolean disableGravity = false;
 	public static int gravityChunkRange = 4;
 
-	// A tick period of 4 and higher is clearly noticeable, especially when entities are affected by
+	// A tick period of 4 and higher is clearly noticeable, especially when entities
+	// are affected by
 	// gravity.
-	// The total performance benefits of higher tick periods also become increasingly smaller and
+	// The total performance benefits of higher tick periods also become
+	// increasingly smaller and
 	// instead result in higher performance impacts per individual behavior update.
-	// The gravity updates at a tick period of 2 actually appear less smooth in my testing than at a
+	// The gravity updates at a tick period of 2 actually appear less smooth in my
+	// testing than at a
 	// period of 3 (maybe due to some interpolation artifact by the client).
 	public static int entityBehaviorTickPeriod = 3;
 
@@ -318,6 +324,8 @@ public class Settings extends Config {
 
 	public static boolean enableContainerOptionOnPlayerShop = true;
 	public static ItemData containerItem = new ItemData(Material.CHEST);
+
+	public static ItemData membersItem = new ItemData(Material.PLAYER_HEAD);
 
 	public static ItemData tradeNotificationsItem = new ItemData(Material.BELL);
 	public static ItemData deleteItem = new ItemData(Material.BONE);
@@ -433,8 +441,11 @@ public class Settings extends Config {
 		public static ItemData nameButtonItem = Unsafe.uncheckedNull();
 		public static ItemData moveButtonItem = Unsafe.uncheckedNull();
 		public static ItemData containerButtonItem = Unsafe.uncheckedNull();
+		public static ItemData membersButtonItem = Unsafe.uncheckedNull();
 		public static ItemData deleteButtonItem = Unsafe.uncheckedNull();
 		public static ItemData hireButtonItem = Unsafe.uncheckedNull();
+
+		public static MemberPermission memberPermissionLevel = MemberPermission.FULL;
 
 		public static ItemData deleteVillagerButtonItem = Unsafe.uncheckedNull();
 		public static ItemData nameVillagerButtonItem = Unsafe.uncheckedNull();
@@ -453,9 +464,11 @@ public class Settings extends Config {
 			initialSetup = false;
 		}
 
-		// Gets called after setting values have changed (e.g. after the config has been loaded):
+		// Gets called after setting values have changed (e.g. after the config has been
+		// loaded):
 		private static void setup() {
-			// TODO This formatter uses the server's default time zone. Allow configuring the time
+			// TODO This formatter uses the server's default time zone. Allow configuring
+			// the time
 			// zone?
 			try {
 				dateTimeFormatter = DateTimeFormatter.ofPattern(Messages.dateTimeFormat)
@@ -473,20 +486,16 @@ public class Settings extends Config {
 					ItemUtils.setDisplayNameAndLore(
 							sellingEmptyTradeResultItem.createItemStack(),
 							Messages.sellingShop_emptyTrade_resultItem,
-							Messages.sellingShop_emptyTrade_resultItemLore
-					),
+							Messages.sellingShop_emptyTrade_resultItemLore),
 					ItemUtils.setDisplayNameAndLore(
 							sellingEmptyTradeItem1.createItemStack(),
 							Messages.sellingShop_emptyTrade_item1,
-							Messages.sellingShop_emptyTrade_item1Lore
-					),
+							Messages.sellingShop_emptyTrade_item1Lore),
 					// The editor item can be configured, even if the high currency is disabled:
 					Currencies.isHighCurrencyEnabled() ? ItemUtils.setDisplayNameAndLore(
 							sellingEmptyTradeItem2.createItemStack(),
 							Messages.sellingShop_emptyTrade_item2,
-							Messages.sellingShop_emptyTrade_item2Lore
-					) : sellingEmptyTradeItem2.createItemStack()
-			);
+							Messages.sellingShop_emptyTrade_item2Lore) : sellingEmptyTradeItem2.createItemStack());
 			sellingEmptyTradeSlotItems = new TradingRecipeDraft(
 					// This item is never used, because the slot is never empty for a non-empty
 					// trade:
@@ -494,95 +503,75 @@ public class Settings extends Config {
 					ItemUtils.setDisplayNameAndLore(
 							sellingEmptyItem1.createItemStack(),
 							Messages.sellingShop_emptyItem1,
-							Messages.sellingShop_emptyItem1Lore
-					),
+							Messages.sellingShop_emptyItem1Lore),
 					// The editor item can be configured, even if the high currency is disabled:
 					Currencies.isHighCurrencyEnabled() ? ItemUtils.setDisplayNameAndLore(
 							sellingEmptyItem2.createItemStack(),
 							Messages.sellingShop_emptyItem2,
-							Messages.sellingShop_emptyItem2Lore
-					) : sellingEmptyItem2.createItemStack()
-			);
+							Messages.sellingShop_emptyItem2Lore) : sellingEmptyItem2.createItemStack());
 			buyingEmptyTrade = new TradingRecipeDraft(
 					ItemUtils.setDisplayNameAndLore(
 							buyingEmptyTradeResultItem.createItemStack(),
 							Messages.buyingShop_emptyTrade_resultItem,
-							Messages.buyingShop_emptyTrade_resultItemLore
-					),
+							Messages.buyingShop_emptyTrade_resultItemLore),
 					ItemUtils.setDisplayNameAndLore(
 							buyingEmptyTradeItem1.createItemStack(),
 							Messages.buyingShop_emptyTrade_item1,
-							Messages.buyingShop_emptyTrade_item1Lore
-					),
+							Messages.buyingShop_emptyTrade_item1Lore),
 					// The editor item can be configured, even though this slot is not used for
 					// anything:
-					buyingEmptyTradeItem2.createItemStack()
-			);
+					buyingEmptyTradeItem2.createItemStack());
 			buyingEmptyTradeSlotItems = new TradingRecipeDraft(
 					ItemUtils.setDisplayNameAndLore(
 							buyingEmptyResultItem.createItemStack(),
 							Messages.buyingShop_emptyResultItem,
-							Messages.buyingShop_emptyResultItemLore
-					),
+							Messages.buyingShop_emptyResultItemLore),
 					// This item is never used, because the slot is never empty for a non-empty
 					// trade:
 					null,
 					// The editor item can be configured, even though this slot is not used for
 					// anything:
-					buyingEmptyItem2.createItemStack()
-			);
+					buyingEmptyItem2.createItemStack());
 			tradingEmptyTrade = new TradingRecipeDraft(
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyTradeResultItem.createItemStack(),
 							Messages.tradingShop_emptyTrade_resultItem,
-							Messages.tradingShop_emptyTrade_resultItemLore
-					),
+							Messages.tradingShop_emptyTrade_resultItemLore),
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyTradeItem1.createItemStack(),
 							Messages.tradingShop_emptyTrade_item1,
-							Messages.tradingShop_emptyTrade_item1Lore
-					),
+							Messages.tradingShop_emptyTrade_item1Lore),
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyTradeItem2.createItemStack(),
 							Messages.tradingShop_emptyTrade_item2,
-							Messages.tradingShop_emptyTrade_item2Lore
-					)
-			);
+							Messages.tradingShop_emptyTrade_item2Lore));
 			tradingEmptyTradeSlotItems = new TradingRecipeDraft(
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyResultItem.createItemStack(),
 							Messages.tradingShop_emptyResultItem,
-							Messages.tradingShop_emptyResultItemLore
-					),
+							Messages.tradingShop_emptyResultItemLore),
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyItem1.createItemStack(),
 							Messages.tradingShop_emptyItem1,
-							Messages.tradingShop_emptyItem1Lore
-					),
+							Messages.tradingShop_emptyItem1Lore),
 					ItemUtils.setDisplayNameAndLore(
 							tradingEmptyItem2.createItemStack(),
 							Messages.tradingShop_emptyItem2,
-							Messages.tradingShop_emptyItem2Lore
-					)
-			);
+							Messages.tradingShop_emptyItem2Lore));
 			bookEmptyTrade = new TradingRecipeDraft(
 					ItemUtils.setDisplayNameAndLore(
 							bookEmptyTradeResultItem.createItemStack(),
 							Messages.bookShop_emptyTrade_resultItem,
-							Messages.bookShop_emptyTrade_resultItemLore
-					),
+							Messages.bookShop_emptyTrade_resultItemLore),
 					ItemUtils.setDisplayNameAndLore(
 							bookEmptyTradeItem1.createItemStack(),
 							Messages.bookShop_emptyTrade_item1,
-							Messages.bookShop_emptyTrade_item1Lore
-					),
+							Messages.bookShop_emptyTrade_item1Lore),
 					// The editor item can be configured, even if the high currency is disabled:
 					Currencies.isHighCurrencyEnabled() ? ItemUtils.setDisplayNameAndLore(
 							bookEmptyTradeItem2.createItemStack(),
 							Messages.bookShop_emptyTrade_item2,
-							Messages.bookShop_emptyTrade_item2Lore
-					) : bookEmptyTradeItem2.createItemStack()
-			);
+							Messages.bookShop_emptyTrade_item2Lore) : bookEmptyTradeItem2.createItemStack());
 			bookEmptyTradeSlotItems = new TradingRecipeDraft(
 					// This item is never used, because the slot is never empty for a non-empty
 					// trade:
@@ -590,15 +579,12 @@ public class Settings extends Config {
 					ItemUtils.setDisplayNameAndLore(
 							bookEmptyItem1.createItemStack(),
 							Messages.bookShop_emptyItem1,
-							Messages.bookShop_emptyItem1Lore
-					),
+							Messages.bookShop_emptyItem1Lore),
 					// The editor item can be configured, even if the high currency is disabled:
 					Currencies.isHighCurrencyEnabled() ? ItemUtils.setDisplayNameAndLore(
 							bookEmptyItem2.createItemStack(),
 							Messages.bookShop_emptyItem2,
-							Messages.bookShop_emptyItem2Lore
-					) : bookEmptyItem2.createItemStack()
-			);
+							Messages.bookShop_emptyItem2Lore) : bookEmptyItem2.createItemStack());
 
 			// If enabled, add the shop creation item tag:
 			if (addShopCreationItemTag) {
@@ -607,76 +593,78 @@ public class Settings extends Config {
 				shopCreationItemHelper.addTag();
 				shopCreationItemHelper.applyItemMeta();
 				shopCreationItemData = new ItemData(UnmodifiableItemStack.ofNonNull(
-						shopCreationItemStack
-				));
+						shopCreationItemStack));
 			} else {
 				shopCreationItemData = shopCreationItem;
 			}
 
-			// Ignore (clear) the display name that is used to specify the substituted item type:
+			// Ignore (clear) the display name that is used to specify the substituted item
+			// type:
 			placeholderItemData = new ItemData(UnmodifiableItemStack.ofNonNull(
-					ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)
-			));
+					ItemUtils.setDisplayName(placeholderItem.createItemStack(), null)));
 
-			// Ignore (clear) the display name that is used to specify the new shopkeeper name, but
+			// Ignore (clear) the display name that is used to specify the new shopkeeper
+			// name, but
 			// keep the lore:
 			namingItemData = new ItemData(UnmodifiableItemStack.ofNonNull(
-					ItemUtils.setDisplayName(nameItem.createItemStack(), null)
-			));
+					ItemUtils.setDisplayName(nameItem.createItemStack(), null)));
 
 			// Button items:
 			shopOpenButtonItem = new ItemData(
 					shopOpenItem,
 					Messages.buttonShopOpen,
-					Messages.buttonShopOpenLore
-			);
+					Messages.buttonShopOpenLore);
 			shopClosedButtonItem = new ItemData(
 					shopClosedItem,
 					Messages.buttonShopClosed,
-					Messages.buttonShopClosedLore
-			);
+					Messages.buttonShopClosedLore);
 			nameButtonItem = new ItemData(
 					nameItem,
 					Messages.buttonName,
-					Messages.buttonNameLore
-			);
+					Messages.buttonNameLore);
 			moveButtonItem = new ItemData(
 					moveItem,
 					Messages.buttonMove,
-					Messages.buttonMoveLore
-			);
+					Messages.buttonMoveLore);
 			containerButtonItem = new ItemData(
 					containerItem,
 					Messages.buttonContainer,
-					Messages.buttonContainerLore
-			);
+					Messages.buttonContainerLore);
+			membersButtonItem = new ItemData(
+					membersItem,
+					Messages.buttonMembers,
+					Messages.buttonMembersLore);
 			deleteButtonItem = new ItemData(
 					deleteItem,
 					Messages.buttonDelete,
-					Messages.buttonDeleteLore
-			);
+					Messages.buttonDeleteLore);
 			hireButtonItem = new ItemData(
 					hireItem,
 					Messages.buttonHire,
-					Messages.buttonHireLore
-			);
+					Messages.buttonHireLore);
+
+			// Parse member permission level:
+			try {
+				memberPermissionLevel = MemberPermission.valueOf(memberPermissions);
+			} catch (IllegalArgumentException e) {
+				Log.warning("Config: Invalid 'member-permissions' value '" + memberPermissions
+						+ "'. Using default: FULL");
+				memberPermissionLevel = MemberPermission.FULL;
+			}
 
 			// Note: These use the same item types as the corresponding shopkeeper buttons.
 			deleteVillagerButtonItem = new ItemData(
 					deleteItem,
 					Messages.buttonDeleteVillager,
-					Messages.buttonDeleteVillagerLore
-			);
+					Messages.buttonDeleteVillagerLore);
 			nameVillagerButtonItem = new ItemData(
 					nameItem,
 					Messages.buttonNameVillager,
-					Messages.buttonNameVillagerLore
-			);
+					Messages.buttonNameVillagerLore);
 			villagerInventoryButtonItem = new ItemData(
 					containerItem,
 					Messages.buttonVillagerInventory,
-					Messages.buttonVillagerInventoryLore
-			);
+					Messages.buttonVillagerInventoryLore);
 
 			// Shop name pattern:
 			try {
@@ -789,19 +777,27 @@ public class Settings extends Config {
 		Plugin plugin = SKShopkeepersPlugin.getInstance();
 		var pluginConfig = plugin.getConfig();
 		// The default dot path separator can cause issues.
-		// For example, since Bukkit 1.20.6, item attribute modifiers are now serialized using the
-		// attribute namespaced keys as section keys, which can contain dots. When saving ItemData
-		// with attribute modifiers, we filter the serialized item meta data (to produce a more
-		// minimal and user-friendly output) and then apply all preserved key-value pairs to this
-		// config-backed DataContainer. Setting values with a key containing dots would by default
-		// result in sub-sections to be created, which fails to properly deserialize later.
+		// For example, since Bukkit 1.20.6, item attribute modifiers are now serialized
+		// using the
+		// attribute namespaced keys as section keys, which can contain dots. When
+		// saving ItemData
+		// with attribute modifiers, we filter the serialized item meta data (to produce
+		// a more
+		// minimal and user-friendly output) and then apply all preserved key-value
+		// pairs to this
+		// config-backed DataContainer. Setting values with a key containing dots would
+		// by default
+		// result in sub-sections to be created, which fails to properly deserialize
+		// later.
 		ConfigUtils.disablePathSeparator(pluginConfig);
-		// This is a wrapper around the Bukkit config. Config comments are preserved by the
+		// This is a wrapper around the Bukkit config. Config comments are preserved by
+		// the
 		// underlying Bukkit config.
 		return ConfigData.of(pluginConfig);
 	}
 
-	// Returns null on success, otherwise a severe issue prevented loading the config.
+	// Returns null on success, otherwise a severe issue prevented loading the
+	// config.
 	public static @Nullable ConfigLoadException loadConfig() {
 		Log.info("Loading config.");
 		Plugin plugin = SKShopkeepersPlugin.getInstance();
@@ -814,9 +810,12 @@ public class Settings extends Config {
 
 		ConfigData configData = getPluginConfigData();
 
-		// The default config is not empty. If the loaded config data is empty, the config file is
-		// either empty (unusual) or the config failed to load. We abort the config loading with an
-		// error here instead of inserting the default settings, because doing so might overwrite
+		// The default config is not empty. If the loaded config data is empty, the
+		// config file is
+		// either empty (unusual) or the config failed to load. We abort the config
+		// loading with an
+		// error here instead of inserting the default settings, because doing so might
+		// overwrite
 		// the user's current config file contents.
 		if (configData.isEmpty()) {
 			return new ConfigLoadException("The config file is empty or could not be loaded."
@@ -834,7 +833,8 @@ public class Settings extends Config {
 		}
 
 		if (configChanged) {
-			// If the config was modified (migrations, adding missing settings, ..), save it:
+			// If the config was modified (migrations, adding missing settings, ..), save
+			// it:
 			saveConfig();
 		}
 		return null; // Config loaded successfully
@@ -857,7 +857,8 @@ public class Settings extends Config {
 		}
 
 		// Load and validate settings:
-		// Load the data version setting first so that it is available for the loading of ItemData
+		// Load the data version setting first so that it is available for the loading
+		// of ItemData
 		// settings:
 		var dataVersionSetting = Settings.INSTANCE.getSetting("data-version");
 		assert dataVersionSetting != null;
@@ -867,7 +868,8 @@ public class Settings extends Config {
 		Settings.INSTANCE.load(configData);
 
 		// Update the data version:
-		// Note: This is done after inserting default values, since the default value might itself
+		// Note: This is done after inserting default values, since the default value
+		// might itself
 		// be outdated (we support a range of Minecraft versions).
 		var dataVersionChanged = Settings.INSTANCE.updateDataVersion();
 		if (dataVersionChanged) {
@@ -879,7 +881,8 @@ public class Settings extends Config {
 	}
 
 	/**
-	 * Applies the values of this config to the config of the {@link ShopkeepersPlugin} and
+	 * Applies the values of this config to the config of the
+	 * {@link ShopkeepersPlugin} and
 	 * {@link Plugin#saveConfig() saves it}.
 	 */
 	public static void saveConfig() {
@@ -951,7 +954,8 @@ public class Settings extends Config {
 			}
 		}
 
-		// Warn about potential configuration mistakes regarding the shop creation item tag:
+		// Warn about potential configuration mistakes regarding the shop creation item
+		// tag:
 		if (identifyShopCreationItemByTag && !addShopCreationItemTag) {
 			Log.warning(this.getLogPrefix() + "'identify-shop-creation-item-by-tag' enabled, "
 					+ "but 'add-shop-creation-item-tag' is disabled! Intended?");
@@ -981,13 +985,16 @@ public class Settings extends Config {
 			tradeLogNextMergeTimeoutTicks = 0;
 		}
 		// Note: If tradeLogNextMergeTimeoutTicks is greater than or equal to
-		// tradeLogMergeDurationTicks, it has no effect. However, we do not print a warning in this
-		// case to allow tradeLogMergeDurationTicks to be easily adjusted inside the config without
+		// tradeLogMergeDurationTicks, it has no effect. However, we do not print a
+		// warning in this
+		// case to allow tradeLogMergeDurationTicks to be easily adjusted inside the
+		// config without
 		// having to keep tradeLogNextMergeTimeoutTicks consistent.
 
 		// Temporary workaround for Mohist and Magma servers.
 		// See https://github.com/Shopkeepers/Shopkeepers/issues/738
-		// TODO This is supposed to be removed again once the underlying issue has been fixed by
+		// TODO This is supposed to be removed again once the underlying issue has been
+		// fixed by
 		// Mohist/Magma.
 		if (!disableInventoryVerification) {
 			String serverName = Bukkit.getServer().getName();
@@ -1019,8 +1026,10 @@ public class Settings extends Config {
 		Log.info(this.getLogPrefix() + "'data-version' updated from " + dataVersion + " to "
 				+ currentDataVersion + ".");
 		dataVersion = currentDataVersion;
-		// Note: Any item data is automatically migrated during loading. This data version check and
-		// updating ensures that we save back the migrated item data whenever the data version has
+		// Note: Any item data is automatically migrated during loading. This data
+		// version check and
+		// updating ensures that we save back the migrated item data whenever the data
+		// version has
 		// changed.
 
 		return true;
@@ -1047,9 +1056,12 @@ public class Settings extends Config {
 				}
 			}
 
-			// No event is called for Material settings: There is no item data based on which
-			// plugins can reasonable decide whether or not to change the material without not also
-			// affecting all items of the same type in other contexts. Plugins that want to update
+			// No event is called for Material settings: There is no item data based on
+			// which
+			// plugins can reasonable decide whether or not to change the material without
+			// not also
+			// affecting all items of the same type in other contexts. Plugins that want to
+			// update
 			// specific Material settings need to do so explicitly.
 		}
 
@@ -1065,7 +1077,8 @@ public class Settings extends Config {
 	private boolean updateItemDataSetting(Setting<ItemData> setting) {
 		var value = setting.getValue(); // Can be null
 		var newItemData = ItemUpdates.updateItemData(value);
-		if (newItemData == value) return false; // Not changed
+		if (newItemData == value)
+			return false; // Not changed
 		assert newItemData != null;
 
 		String configKey = setting.getConfigKey();
@@ -1086,7 +1099,8 @@ public class Settings extends Config {
 
 	private int updateItemDataListSetting(Setting<List<ItemData>> setting) {
 		var value = setting.getValue();
-		if (value == null) return 0; // Nothing to update
+		if (value == null)
+			return 0; // Nothing to update
 
 		int updatedItems = 0;
 
@@ -1094,9 +1108,11 @@ public class Settings extends Config {
 		var iterator = value.listIterator();
 		while (iterator.hasNext()) {
 			index += 1;
-			@Nullable ItemData itemData = iterator.next(); // Can be null
+			@Nullable
+			ItemData itemData = iterator.next(); // Can be null
 			var newItemData = ItemUpdates.updateItemData(itemData);
-			if (newItemData == itemData) continue; // Not changed
+			if (newItemData == itemData)
+				continue; // Not changed
 			assert newItemData != null;
 
 			String configKey = setting.getConfigKey();

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/container/protection/ProtectedContainers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/container/protection/ProtectedContainers.java
@@ -31,34 +31,47 @@ import com.nisovin.shopkeepers.util.java.Validate;
  * <b>Container protection.</b>
  * <p>
  * <b>Protected containers:</b><br>
- * A container directly used by a player shopkeeper is 'directly protected'. Any adjacent chests (N,
- * W, S, E) that form a double chest with a directly protected chest are protected as well.
+ * A container directly used by a player shopkeeper is 'directly protected'. Any
+ * adjacent chests (N,
+ * W, S, E) that form a double chest with a directly protected chest are
+ * protected as well.
  * <p>
  * <b>Bypass:</b><br>
- * The owner of a shop corresponding to a protected container and players with the bypass permission
- * are not affected by the listed protections. Also, certain protections can be disabled via config
+ * The owner of a shop corresponding to a protected container and players with
+ * the bypass permission
+ * are not affected by the listed protections. Also, certain protections can be
+ * disabled via config
  * settings.
  * <p>
  * <b>Protections:</b><br>
  * <ul>
  * <li>Protected containers cannot be accessed.
  * <li>Protected containers cannot be broken or destroyed by explosions.
- * <li>Protected containers don't transfer items, e.g. into or from hoppers, droppers, etc.
- * <li>Chests cannot be placed adjacent to a directly protected chest, if they would connect to it
+ * <li>Protected containers don't transfer items, e.g. into or from hoppers,
+ * droppers, etc.
+ * <li>Chests cannot be placed adjacent to a directly protected chest, if they
+ * would connect to it
  * and form a double chest.
- * <li>Hoppers and droppers cannot be placed adjacent to a protected container, if they would be
+ * <li>Hoppers and droppers cannot be placed adjacent to a protected container,
+ * if they would be
  * able to receive or inject items.
- * <li>Rails cannot be placed below a protected container (to prevent hopper carts stealing items).
+ * <li>Rails cannot be placed below a protected container (to prevent hopper
+ * carts stealing items).
  * </ul>
  * Note that there is no protection for the following cases:
  * <ul>
- * <li>Even though rails cannot be placed below protected containers, hopper carts are still able to
- * be placed / pushed to end up below protected containers. The item movement protection will
+ * <li>Even though rails cannot be placed below protected containers, hopper
+ * carts are still able to
+ * be placed / pushed to end up below protected containers. The item movement
+ * protection will
  * however still prevent items from being extracted from the container.
- * <li>Adjacent unconnected chests are not protected. It should however not be possible to access
+ * <li>Adjacent unconnected chests are not protected. It should however not be
+ * possible to access
  * any protected adjacent chest by that.
- * <li>Adjacent or chains of droppers and hoppers are not protected. So if item movement is enabled
- * in the config and the shop owner places those connected to his shop container, other players will
+ * <li>Adjacent or chains of droppers and hoppers are not protected. So if item
+ * movement is enabled
+ * in the config and the shop owner places those connected to his shop
+ * container, other players will
  * be able to access (or break) them.
  * </ul>
  */
@@ -68,8 +81,10 @@ public class ProtectedContainers {
 	private static final MutableBlockLocation sharedBlockLocation = new MutableBlockLocation();
 
 	private final SKShopkeepersPlugin plugin;
-	private final ContainerProtectionListener containerProtectionListener = new ContainerProtectionListener(Unsafe.initialized(this));
-	private final InventoryMoveItemListener inventoryMoveItemListener = new InventoryMoveItemListener(Unsafe.initialized(this));
+	private final ContainerProtectionListener containerProtectionListener = new ContainerProtectionListener(
+			Unsafe.initialized(this));
+	private final InventoryMoveItemListener inventoryMoveItemListener = new InventoryMoveItemListener(
+			Unsafe.initialized(this));
 	private final Map<BlockLocation, List<AbstractPlayerShopkeeper>> protectedContainers = new HashMap<>();
 
 	public ProtectedContainers(SKShopkeepersPlugin plugin) {
@@ -102,8 +117,7 @@ public class ProtectedContainers {
 		Validate.notNull(shopkeeper, "shopkeeper is null");
 		List<AbstractPlayerShopkeeper> shopkeepers = protectedContainers.computeIfAbsent(
 				location.immutable(),
-				key -> new ArrayList<>(1)
-		);
+				key -> new ArrayList<>(1));
 		assert shopkeepers != null;
 		shopkeepers.add(shopkeeper);
 	}
@@ -111,8 +125,10 @@ public class ProtectedContainers {
 	public void removeContainer(BlockLocation location, AbstractPlayerShopkeeper shopkeeper) {
 		Validate.notNull(location, "location is null");
 		Validate.notNull(shopkeeper, "shopkeeper is null");
-		// This operation either updates the value inside the Map, or removes it. It does not insert
-		// a new entry for the passed key. We can therefore safely use the given location, without
+		// This operation either updates the value inside the Map, or removes it. It
+		// does not insert
+		// a new entry for the passed key. We can therefore safely use the given
+		// location, without
 		// first creating an immutable copy of it.
 		protectedContainers.computeIfPresent(location, (key, shopkeepers) -> {
 			shopkeepers.remove(shopkeeper);
@@ -125,13 +141,13 @@ public class ProtectedContainers {
 		});
 	}
 
-	// Gets the shopkeepers that are directly using the container at the specified location:
+	// Gets the shopkeepers that are directly using the container at the specified
+	// location:
 	private @Nullable List<? extends AbstractPlayerShopkeeper> _getShopkeepers(
 			String worldName,
 			int x,
 			int y,
-			int z
-	) {
+			int z) {
 		BlockLocation key = this.getSharedKey(worldName, x, y, z);
 		return protectedContainers.get(key);
 	}
@@ -142,17 +158,16 @@ public class ProtectedContainers {
 				block.getWorld().getName(),
 				block.getX(),
 				block.getY(),
-				block.getZ()
-		);
+				block.getZ());
 	}
 
-	// Gets the shopkeepers that are directly using the container at the specified location:
+	// Gets the shopkeepers that are directly using the container at the specified
+	// location:
 	public List<? extends PlayerShopkeeper> getShopkeepers(
 			String worldName,
 			int x,
 			int y,
-			int z
-	) {
+			int z) {
 		List<? extends PlayerShopkeeper> shopkeepers = this._getShopkeepers(worldName, x, y, z);
 		if (shopkeepers != null) {
 			return Collections.unmodifiableList(shopkeepers);
@@ -166,8 +181,7 @@ public class ProtectedContainers {
 				block.getWorld().getName(),
 				block.getX(),
 				block.getY(),
-				block.getZ()
-		);
+				block.getZ());
 	}
 
 	//
@@ -178,23 +192,26 @@ public class ProtectedContainers {
 			int x,
 			int y,
 			int z,
-			@Nullable Player player
-	) {
+			@Nullable Player player) {
 		List<? extends PlayerShopkeeper> shopkeepers = this._getShopkeepers(worldName, x, y, z);
 		// Check if there are any shopkeepers using this container:
-		if (shopkeepers == null) return false;
+		if (shopkeepers == null)
+			return false;
 		assert !shopkeepers.isEmpty();
 		if (player != null) {
 			// Check whether the player is affected by the protection:
 			// Note: The bypass permission does not get checked here but needs to be checked
 			// separately.
-			// We always allow shop owners to access their shop container (regardless of other
-			// shopkeepers using the same container):
+			// We always allow shop owners and members to access their shop container
+			// (regardless
+			// of other shopkeepers using the same container):
 			for (PlayerShopkeeper shopkeeper : shopkeepers) {
-				if (shopkeeper.isOwner(player)) return false;
+				if (shopkeeper.isOwner(player) || shopkeeper.isMember(player))
+					return false;
 			}
 		}
-		// There exists a protection for this container and the player doesn't own any shopkeeper
+		// There exists a protection for this container and the player doesn't own any
+		// shopkeeper
 		// using it:
 		return true;
 	}
@@ -205,8 +222,7 @@ public class ProtectedContainers {
 				block.getX(),
 				block.getY(),
 				block.getZ(),
-				player
-		);
+				player);
 	}
 
 	//
@@ -220,17 +236,22 @@ public class ProtectedContainers {
 	 * The block is protected if either:
 	 * <ul>
 	 * <li>The container block is directly used by a shopkeeper.
-	 * <li>The block is a chest that is connected to another chest block (forms a double chest)
+	 * <li>The block is a chest that is connected to another chest block (forms a
+	 * double chest)
 	 * which is directly used by a shopkeeper.
 	 * </ul>
 	 * <p>
-	 * Optionally, this takes shop editing access for the specified player into account.
+	 * Optionally, this takes shop editing access for the specified player into
+	 * account.
 	 * 
 	 * @param containerBlock
-	 *            the container block (the block might not actually be a container anymore though)
+	 *                       the container block (the block might not actually be a
+	 *                       container anymore though)
 	 * @param player
-	 *            the player to check the protection for, or <code>null</code> to check for
-	 *            protection without taking shop editing access into account
+	 *                       the player to check the protection for, or
+	 *                       <code>null</code> to check for
+	 *                       protection without taking shop editing access into
+	 *                       account
 	 * @return <code>true</code> if the block is protected
 	 */
 	public boolean isContainerProtected(Block containerBlock, @Nullable Player player) {
@@ -246,7 +267,8 @@ public class ProtectedContainers {
 		boolean result = true;
 		// Check if the player is affected by the protection:
 		if (player != null) {
-			// We always allow shop owners to access their shop container (regardless of other
+			// We always allow shop owners to access their shop container (regardless of
+			// other
 			// shopkeepers using the same container):
 			for (AbstractPlayerShopkeeper shopkeeper : tempResultsList) {
 				if (shopkeeper.canEdit(player, true)) {
@@ -263,11 +285,13 @@ public class ProtectedContainers {
 	/**
 	 * Checks if the given block is a protected shop container.
 	 * <p>
-	 * This checks if the specified block actually is a supported type of shop container. This does
-	 * not take any players into account, such as shop owners or players with the bypass permission.
+	 * This checks if the specified block actually is a supported type of shop
+	 * container. This does
+	 * not take any players into account, such as shop owners or players with the
+	 * bypass permission.
 	 * 
 	 * @param block
-	 *            the block
+	 *              the block
 	 * @return <code>true</code> if the block is a protected container
 	 */
 	public boolean isProtectedContainer(Block block) {
@@ -277,14 +301,16 @@ public class ProtectedContainers {
 	/**
 	 * Checks if the given block is a protected shop container.
 	 * <p>
-	 * This checks if the specified block actually is a supported type of shop container currently,
+	 * This checks if the specified block actually is a supported type of shop
+	 * container currently,
 	 * and optionally takes shop editing access for the specified player account.
 	 * 
 	 * @param block
-	 *            the block
+	 *               the block
 	 * @param player
-	 *            the player to check the protection for, or <code>null</code> to check for
-	 *            protection without taking shop editing access into account
+	 *               the player to check the protection for, or <code>null</code> to
+	 *               check for
+	 *               protection without taking shop editing access into account
 	 * @return <code>true</code> if the block is a protected container
 	 */
 	public boolean isProtectedContainer(Block block, @Nullable Player player) {
@@ -295,18 +321,19 @@ public class ProtectedContainers {
 		return this.isContainerProtected(block, player);
 	}
 
-	// Gets the shopkeepers which use the container at the given location (directly or by a
+	// Gets the shopkeepers which use the container at the given location (directly
+	// or by a
 	// connected chest):
 	public List<? extends PlayerShopkeeper> getShopkeepersUsingContainer(Block containerBlock) {
 		return this.getShopkeepersUsingContainer(containerBlock, new ArrayList<>());
 	}
 
-	// Gets the shopkeepers which use the container at the given location (directly or by a
+	// Gets the shopkeepers which use the container at the given location (directly
+	// or by a
 	// connected chest), and adds them to the provided list:
 	private List<? extends AbstractPlayerShopkeeper> getShopkeepersUsingContainer(
 			Block containerBlock,
-			List<AbstractPlayerShopkeeper> results
-	) {
+			List<AbstractPlayerShopkeeper> results) {
 		Validate.notNull(containerBlock, "containerBlock is null!");
 		Validate.notNull(results, "results is null!");
 
@@ -325,9 +352,11 @@ public class ProtectedContainers {
 			BlockFace connectedFace = getConnectedBlockFace(chestFacing, chestData.getType());
 			if (connectedFace != null) {
 				Block connectedChest = containerBlock.getRelative(connectedFace);
-				// In case of inconsistency of the block data (i.e. connected chest missing or not
+				// In case of inconsistency of the block data (i.e. connected chest missing or
+				// not
 				// mutually connected), we consider the block to be connected (and by that
-				// protected) anyway, because such inconsistencies might also occur during handling
+				// protected) anyway, because such inconsistencies might also occur during
+				// handling
 				// of block placements.
 				// Minecraft determines double chests by these consistency criteria:
 				// Same chest type, same facing, opposite chest type (opposite connected block
@@ -343,44 +372,44 @@ public class ProtectedContainers {
 
 	private static @Nullable BlockFace getConnectedBlockFace(BlockFace chestFacing, Type chestType) {
 		switch (chestFacing) {
-		case NORTH:
-			switch (chestType) {
-			case RIGHT:
-				return BlockFace.WEST;
-			case LEFT:
-				return BlockFace.EAST;
+			case NORTH:
+				switch (chestType) {
+					case RIGHT:
+						return BlockFace.WEST;
+					case LEFT:
+						return BlockFace.EAST;
+					default:
+						return null; // Not connected
+				}
+			case EAST:
+				switch (chestType) {
+					case RIGHT:
+						return BlockFace.NORTH;
+					case LEFT:
+						return BlockFace.SOUTH;
+					default:
+						return null; // Not connected
+				}
+			case SOUTH:
+				switch (chestType) {
+					case RIGHT:
+						return BlockFace.EAST;
+					case LEFT:
+						return BlockFace.WEST;
+					default:
+						return null; // Not connected
+				}
+			case WEST:
+				switch (chestType) {
+					case RIGHT:
+						return BlockFace.SOUTH;
+					case LEFT:
+						return BlockFace.NORTH;
+					default:
+						return null; // Not connected
+				}
 			default:
-				return null; // Not connected
-			}
-		case EAST:
-			switch (chestType) {
-			case RIGHT:
-				return BlockFace.NORTH;
-			case LEFT:
-				return BlockFace.SOUTH;
-			default:
-				return null; // Not connected
-			}
-		case SOUTH:
-			switch (chestType) {
-			case RIGHT:
-				return BlockFace.EAST;
-			case LEFT:
-				return BlockFace.WEST;
-			default:
-				return null; // Not connected
-			}
-		case WEST:
-			switch (chestType) {
-			case RIGHT:
-				return BlockFace.SOUTH;
-			case LEFT:
-				return BlockFace.NORTH;
-			default:
-				return null; // Not connected
-			}
-		default:
-			return null; // Invalid chest facing
+				return null; // Invalid chest facing
 		}
 	}
 }

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/lang/Messages.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/lang/Messages.java
@@ -27,7 +27,8 @@ import com.nisovin.shopkeepers.util.logging.Log;
 @WithValueTypeProvider(ColoredStringListValue.Provider.class)
 public class Messages extends Config {
 
-	// TODO Replace all with Text? Will require converting back to String, especially for texts used
+	// TODO Replace all with Text? Will require converting back to String,
+	// especially for texts used
 	// by items.
 	public static String dateTimeFormat = c("yyyy-MM-dd HH:mm:ss");
 
@@ -54,11 +55,11 @@ public class Messages extends Config {
 	public static Text creationItemSelected = Text.parse("&aShop creation:\n"
 			+ "&e  Do not aim at any block. Then:{shopTypeSelection}{objectTypeSelection}\n"
 			+ "&e  Right-click a container to select it.\n"
-			+ "&e  Then right-click a block to place the shopkeeper."
-	);
+			+ "&e  Then right-click a block to place the shopkeeper.");
 
 	public static Text creationItemShopTypeSelection = Text.parse("\n&e  Left/Right-click to select the shop type.");
-	public static Text creationItemObjectTypeSelection = Text.parse("\n&e  Sneak + left/right-click to select the object type.");
+	public static Text creationItemObjectTypeSelection = Text
+			.parse("\n&e  Sneak + left/right-click to select the object type.");
 
 	public static String stateEnabled = c("&2Enabled");
 	public static String stateDisabled = c("&4Disabled");
@@ -76,321 +77,261 @@ public class Messages extends Config {
 	public static List<String> buttonShopOpenLore = c(Arrays.asList(
 			"Temporarily closes the shop.",
 			"Currently: &2Open",
-			"&2Players can trade."
-	));
+			"&2Players can trade."));
 	public static String buttonShopClosed = c("&aOpen shop");
 	public static List<String> buttonShopClosedLore = c(Arrays.asList(
 			"Re-opens the shop.",
 			"Currently: &4Closed",
-			"&4Players cannot trade."
-	));
+			"&4Players cannot trade."));
 	public static String buttonName = c("&aSet shop name");
 	public static List<String> buttonNameLore = c(Arrays.asList(
 			"Lets you rename",
-			"your shopkeeper"
-	));
+			"your shopkeeper"));
 	public static String buttonEquipment = c("&aEquipment");
 	public static List<String> buttonEquipmentLore = c(Arrays.asList(
 			"Assign equipment.",
 			"Note: Not all mobs support",
-			"the same equipment slots."
-	));
+			"the same equipment slots."));
 	public static String buttonMove = c("&aMove shopkeeper");
 	public static List<String> buttonMoveLore = c(Arrays.asList(
 			"Lets you move",
-			"your shopkeeper"
-	));
+			"your shopkeeper"));
 	public static String buttonContainer = c("&aView shop inventory");
 	public static List<String> buttonContainerLore = c(Arrays.asList(
 			"Lets you view the inventory",
-			"your shopkeeper is using"
-	));
+			"your shopkeeper is using"));
+	public static String buttonMembers = c("&aManage Members");
+	public static List<String> buttonMembersLore = c(Arrays.asList(
+			"Add or remove members",
+			"who can help manage",
+			"this shop"));
 	public static String buttonTradeNotifications = c("&aTrade Notifications");
 	public static List<String> buttonTradeNotificationsLore = c(Arrays.asList(
 			"Toggles trade notifications",
 			"for this shopkeeper on/off.",
-			"Currently: {state}"
-	));
+			"Currently: {state}"));
 	public static String buttonDelete = c("&4Delete");
 	public static List<String> buttonDeleteLore = c(Arrays.asList(
 			"Closes and removes",
-			"this shopkeeper"
-	));
+			"this shopkeeper"));
 
 	public static String buttonSignVariant = c("&aChoose sign variant");
 	public static List<String> buttonSignVariantLore = c(Arrays.asList(
 			"Changes the sign's",
-			"wood type"
-	));
+			"wood type"));
 	public static String buttonSignGlowingText = c("&aToggle glowing text");
 	public static List<String> buttonSignGlowingTextLore = c(Arrays.asList(
 			"Toggles glowing text",
-			"on and off"
-	));
+			"on and off"));
 	public static String buttonBaby = c("&aToggle baby variant");
 	public static List<String> buttonBabyLore = c(Arrays.asList(
 			"Toggles between the mob's",
-			"baby and adult variant"
-	));
+			"baby and adult variant"));
 	public static String buttonSitting = c("&aToggle sitting pose");
 	public static List<String> buttonSittingLore = c(Arrays.asList(
 			"Toggles the mob's",
-			"sitting pose"
-	));
+			"sitting pose"));
 	public static String buttonCatVariant = c("&aChoose cat variant");
 	public static List<String> buttonCatVariantLore = c(Arrays.asList(
-			"Changes the cat's look"
-	));
+			"Changes the cat's look"));
 	public static String buttonRabbitVariant = c("&aChoose rabbit variant");
 	public static List<String> buttonRabbitVariantLore = c(Arrays.asList(
-			"Changes the rabbit's look"
-	));
+			"Changes the rabbit's look"));
 	public static String buttonCollarColor = c("&aChoose collar color");
 	public static List<String> buttonCollarColorLore = c(Arrays.asList(
 			"Changes the mob's",
-			"collar color"
-	));
+			"collar color"));
 	public static String buttonWolfAngry = c("&aToggle angry wolf");
 	public static List<String> buttonWolfAngryLore = c(Arrays.asList(
 			"Toggles the wolf's",
-			"angry state"
-	));
+			"angry state"));
 	public static String buttonCarryingChest = c("&aToggle carrying chest");
 	public static List<String> buttonCarryingChestLore = c(Arrays.asList(
 			"Toggles whether the mob",
-			"is carrying a chest"
-	));
+			"is carrying a chest"));
 	public static String buttonHorseColor = c("&aChoose horse color");
 	public static List<String> buttonHorseColorLore = c(Arrays.asList(
 			"Changes the color",
-			"of the horse"
-	));
+			"of the horse"));
 	public static String buttonHorseStyle = c("&aChoose horse style");
 	public static List<String> buttonHorseStyleLore = c(Arrays.asList(
 			"Changes the coat pattern",
-			"of the horse"
-	));
+			"of the horse"));
 	public static String buttonHorseArmor = c("&aChoose horse armor");
 	public static List<String> buttonHorseArmorLore = c(Arrays.asList(
 			"Changes the armor",
-			"of the horse"
-	));
+			"of the horse"));
 	public static String buttonLlamaVariant = c("&aChoose llama variant");
 	public static List<String> buttonLlamaVariantLore = c(Arrays.asList(
-			"Changes the llama's look"
-	));
+			"Changes the llama's look"));
 	public static String buttonLlamaCarpetColor = c("&aLlama carpet color");
 	public static List<String> buttonLlamaCarpetColorLore = c(Arrays.asList(
 			"Changes the llama's",
-			"carpet color"
-	));
+			"carpet color"));
 	public static String buttonCreeperCharged = c("&aToggle charged creeper");
 	public static List<String> buttonCreeperChargedLore = c(Arrays.asList(
 			"Toggles the creeper's",
-			"charged state"
-	));
+			"charged state"));
 	public static String buttonFoxVariant = c("&aChoose fox variant");
 	public static List<String> buttonFoxVariantLore = c(Arrays.asList(
-			"Changes the fox's look"
-	));
+			"Changes the fox's look"));
 	public static String buttonFoxCrouching = c("&aToggle crouching pose");
 	public static List<String> buttonFoxCrouchingLore = c(Arrays.asList(
 			"Toggles the fox's",
-			"crouching pose"
-	));
+			"crouching pose"));
 	public static String buttonFoxSleeping = c("&aToggle sleeping pose");
 	public static List<String> buttonFoxSleepingLore = c(Arrays.asList(
 			"Toggles the fox's",
-			"sleeping pose"
-	));
+			"sleeping pose"));
 	public static String buttonCowVariant = c("&aChoose cow variant");
 	public static List<String> buttonCowVariantLore = c(Arrays.asList(
-			"Changes the cow's look"
-	));
+			"Changes the cow's look"));
 	public static String buttonMooshroomVariant = c("&aChoose mooshroom variant");
 	public static List<String> buttonMooshroomVariantLore = c(Arrays.asList(
 			"Changes the look",
-			"of the mooshroom"
-	));
+			"of the mooshroom"));
 	public static String buttonPandaVariant = c("&aChoose panda variant");
 	public static List<String> buttonPandaVariantLore = c(Arrays.asList(
-			"Changes the panda's look"
-	));
+			"Changes the panda's look"));
 	public static String buttonParrotVariant = c("&aChoose parrot variant");
 	public static List<String> buttonParrotVariantLore = c(Arrays.asList(
-			"Changes the parrot's look"
-	));
+			"Changes the parrot's look"));
 	public static String buttonPigVariant = c("&aChoose pig variant");
 	public static List<String> buttonPigVariantLore = c(Arrays.asList(
-			"Changes the pig's look"
-	));
+			"Changes the pig's look"));
 	public static String buttonChickenVariant = c("&aChoose chicken variant");
 	public static List<String> buttonChickenVariantLore = c(Arrays.asList(
-			"Changes the chicken's look"
-	));
+			"Changes the chicken's look"));
 	public static String buttonSheepColor = c("&aChoose sheep color");
 	public static List<String> buttonSheepColorLore = c(Arrays.asList(
 			"Changes the sheep's",
-			"wool color"
-	));
+			"wool color"));
 	public static String buttonSheepSheared = c("&aToggle sheared sheep");
 	public static List<String> buttonSheepShearedLore = c(Arrays.asList(
 			"Toggles the sheep's",
-			"sheared state"
-	));
+			"sheared state"));
 	public static String buttonVillagerProfession = c("&aChoose villager profession");
 	public static List<String> buttonVillagerProfessionLore = c(Arrays.asList(
 			"Changes the profession",
-			"of the villager"
-	));
+			"of the villager"));
 	public static String buttonVillagerVariant = c("&aChoose villager variant");
 	public static List<String> buttonVillagerVariantLore = c(Arrays.asList(
 			"Changes the look",
-			"of the villager"
-	));
+			"of the villager"));
 	public static String buttonVillagerLevel = c("&aChoose villager badge color");
 	public static List<String> buttonVillagerLevelLore = c(Arrays.asList(
 			"Changes the badge color",
-			"of the villager"
-	));
+			"of the villager"));
 	public static String buttonZombieVillagerProfession = c("&aChoose villager profession");
 	public static List<String> buttonZombieVillagerProfessionLore = c(Arrays.asList(
 			"Changes the profession",
-			"of the zombie villager"
-	));
+			"of the zombie villager"));
 	public static String buttonSlimeSize = c("&aChoose slime size");
 	public static List<String> buttonSlimeSizeLore = c(Arrays.asList(
 			"Cycles the slime's size.",
-			"Current size: &e{size}"
-	));
+			"Current size: &e{size}"));
 	public static String buttonMagmaCubeSize = c("&aChoose magma cube size");
 	public static List<String> buttonMagmaCubeSizeLore = c(Arrays.asList(
 			"Cycles the magma cube's size.",
-			"Current size: &e{size}"
-	));
+			"Current size: &e{size}"));
 	public static String buttonSnowmanPumpkinHead = c("&aToggle pumpkin head");
 	public static List<String> buttonSnowmanPumpkinHeadLore = c(Arrays.asList(
 			"Toggles the snowman's",
-			"pumpkin head"
-	));
+			"pumpkin head"));
 	public static String buttonShulkerColor = c("&aChoose shulker color");
 	public static List<String> buttonShulkerColorLore = c(Arrays.asList(
 			"Changes the color",
-			"of the shulker"
-	));
+			"of the shulker"));
 	public static String buttonAxolotlVariant = c("&aChoose axolotl variant");
 	public static List<String> buttonAxolotlVariantLore = c(Arrays.asList(
-			"Changes the axolotl's look"
-	));
+			"Changes the axolotl's look"));
 	public static String buttonGlowSquidDark = c("&aToggle glow");
 	public static List<String> buttonGlowSquidDarkLore = c(Arrays.asList(
 			"Toggles the glow squid's",
-			"glow on and off"
-	));
+			"glow on and off"));
 	public static String buttonGoatScreaming = c("&aToggle screaming goat");
 	public static List<String> buttonGoatScreamingLore = c(Arrays.asList(
 			"Toggles between a normal",
-			"and a screaming goat"
-	));
+			"and a screaming goat"));
 	public static String buttonGoatLeftHorn = c("&aToggle left horn");
 	public static List<String> buttonGoatLeftHornLore = c(Arrays.asList(
 			"Toggles the goat's",
-			"left horn"
-	));
+			"left horn"));
 	public static String buttonGoatRightHorn = c("&aToggle right horn");
 	public static List<String> buttonGoatRightHornLore = c(Arrays.asList(
 			"Toggles the goat's",
-			"right horn"
-	));
+			"right horn"));
 	public static String buttonTropicalFishPattern = c("&aChoose variant");
 	public static List<String> buttonTropicalFishPatternLore = c(Arrays.asList(
 			"Changes the shape and pattern",
 			"of the tropical fish.",
-			"Currently: &e{pattern}"
-	));
+			"Currently: &e{pattern}"));
 	public static String buttonTropicalFishBodyColor = c("&aChoose body color");
 	public static List<String> buttonTropicalFishBodyColorLore = c(Arrays.asList(
 			"Changes the body color",
-			"of the tropical fish"
-	));
+			"of the tropical fish"));
 	public static String buttonTropicalFishPatternColor = c("&aChoose pattern color");
 	public static List<String> buttonTropicalFishPatternColorLore = c(Arrays.asList(
 			"Changes the pattern color",
-			"of the tropical fish"
-	));
+			"of the tropical fish"));
 	public static String buttonPufferFishPuffState = c("&aChoose puff state");
 	public static List<String> buttonPufferFishPuffStateLore = c(Arrays.asList(
 			"Changes the puff state",
 			"of the puffer fish.",
-			"Currently: &e{puffState}"
-	));
+			"Currently: &e{puffState}"));
 	public static String buttonSalmonVariant = c("&aChoose variant");
 	public static List<String> buttonSalmonVariantLore = c(Arrays.asList(
 			"Changes the size",
-			"of the salmon."
-	));
+			"of the salmon."));
 	public static String buttonFrogVariant = c("&aChoose frog variant");
 	public static List<String> buttonFrogVariantLore = c(Arrays.asList(
-			"Changes the frog's look"
-	));
+			"Changes the frog's look"));
 	public static String buttonWolfVariant = c("&aChoose wolf variant");
 	public static List<String> buttonWolfVariantLore = c(Arrays.asList(
-			"Changes the wolf's look"
-	));
+			"Changes the wolf's look"));
 	public static String buttonSaddle = c("&aToggle saddle");
 	public static List<String> buttonSaddleLore = c(Arrays.asList(
-			"Toggles the mob's saddle"
-	));
+			"Toggles the mob's saddle"));
 	public static String buttonCopperGolemWeatherState = c("&aChoose oxidation level");
 	public static List<String> buttonCopperGolemWeatherStateLore = c(Arrays.asList(
 			"Changes the copper golem's",
-			"oxidation level"
-	));
+			"oxidation level"));
 	public static String buttonArmorStandBasePlate = c("&aToggle base plate");
 	public static List<String> buttonArmorStandBasePlateLore = c(Arrays.asList(
 			"Toggles the base plate",
-			"of the armor stand"
-	));
+			"of the armor stand"));
 	public static String buttonArmorStandShowArms = c("&aToggle arms");
 	public static List<String> buttonArmorStandShowArmsLore = c(Arrays.asList(
 			"Toggles the arms",
-			"of the armor stand"
-	));
+			"of the armor stand"));
 	public static String buttonArmorStandSmall = c("&aToggle size");
 	public static List<String> buttonArmorStandSmallLore = c(Arrays.asList(
 			"Toggles the size",
-			"of the armor stand"
-	));
+			"of the armor stand"));
 	public static String buttonMannequinMainHand = c("&aToggle main hand");
 	public static List<String> buttonMannequinMainHandLore = c(Arrays.asList(
 			"Toggles the main hand",
-			"of the mannequin"
-	));
+			"of the mannequin"));
 	public static String buttonMannequinPose = c("&aToggle pose");
 	public static List<String> buttonMannequinPoseLore = c(Arrays.asList(
 			"Toggles the pose",
-			"of the mannequin"
-	));
+			"of the mannequin"));
 	public static String buttonMannequinProfile = c("&aChange skin");
 	public static List<String> buttonMannequinProfileLore = c(Arrays.asList(
 			"Changes the skin",
-			"of the mannequin"
-	));
+			"of the mannequin"));
 	public static String buttonNautilusArmor = c("&aChoose armor");
 	public static List<String> buttonNautilusArmorLore = c(Arrays.asList(
 			"Changes the armor",
-			"of the nautilus"
-	));
+			"of the nautilus"));
 	public static String buttonZombieNautilusVariant = c("&aChoose variant");
 	public static List<String> buttonZombieNautilusVariantLore = c(Arrays.asList(
 			"Changes the look of",
-			"the zombie nautilus."
-	));
+			"the zombie nautilus."));
 	public static String buttonEndCrystalBottomSlab = c("&aToggle bottom slab");
 	public static List<String> buttonEndCrystalBottomSlabLore = c(Arrays.asList(
 			"Toggles the bottom slab",
-			"of the end crystal"
-	));
+			"of the end crystal"));
 
 	public static Text mannequinEnterProfile = Text.parse(
 			"&aPlease enter in chat the name or id of the player whose profile you want to apply to"
@@ -406,8 +347,7 @@ public class Messages extends Config {
 	public static List<String> equipmentSlotLore = c(Arrays.asList(
 			"Place an item to equip it.",
 			"Right-click to clear",
-			"the equipment slot."
-	));
+			"the equipment slot."));
 
 	public static String equipmentSlotMainhand = c("&aMainhand");
 	public static String equipmentSlotOffhand = c("&aOffhand");
@@ -431,8 +371,7 @@ public class Messages extends Config {
 	public static String forHireTitle = c("For Hire");
 	public static String buttonHire = c("&aHire");
 	public static List<String> buttonHireLore = c(Arrays.asList(
-			"Buy this shopkeeper"
-	));
+			"Buy this shopkeeper"));
 
 	public static String tradingTitlePrefix = c("&2");
 	public static String tradingTitleDefault = c("Shopkeeper");
@@ -442,20 +381,24 @@ public class Messages extends Config {
 	public static Text spawnBlockNotEmpty = Text.parse("&7The spawn location must be empty.");
 	public static Text cannotSpawnMidair = Text.parse("&7The selected shop object cannot be placed in midair.");
 	public static Text invalidSpawnBlockFace = Text.parse("&7The shopkeeper cannot be placed on this side of the block.");
-	public static Text mobCannotSpawnOnPeacefulDifficulty = Text.parse("&7The selected mob type cannot spawn here on peaceful difficulty.");
+	public static Text mobCannotSpawnOnPeacefulDifficulty = Text
+			.parse("&7The selected mob type cannot spawn here on peaceful difficulty.");
 	public static Text restrictedArea = Text.parse("&7You cannot place a shopkeeper in this area.");
 	public static Text locationAlreadyInUse = Text.parse("&7This location is already used by another shopkeeper.");
 	public static Text endCrystalDisabledInTheEnd = Text.parse("&7End crystal shops cannot be placed in the end.");
 	public static Text cannotSpawn = Text.parse("&7The shopkeeper cannot spawn here.");
 
-	public static Text containerSelected = Text.parse("&aContainer selected! Right-click a block to place your shopkeeper.");
+	public static Text containerSelected = Text
+			.parse("&aContainer selected! Right-click a block to place your shopkeeper.");
 	public static Text unsupportedContainer = Text.parse("&7This type of container cannot be used for shops.");
-	public static Text mustSelectContainer = Text.parse("&7You must right-click a container before placing your shopkeeper.");
+	public static Text mustSelectContainer = Text
+			.parse("&7You must right-click a container before placing your shopkeeper.");
 	public static Text mustTargetContainer = Text.parse("&7You must look at a container to place this type of shop.");
 	public static Text invalidContainer = Text.parse("&7The selected block is not a valid container!");
 	public static Text containerTooFarAway = Text.parse("&7The shopkeeper's container is too far away!");
 	public static Text containerNotPlaced = Text.parse("&7You must select a container you have recently placed!");
-	public static Text containerAlreadyInUse = Text.parse("&7Another shopkeeper is already using the selected container!");
+	public static Text containerAlreadyInUse = Text
+			.parse("&7Another shopkeeper is already using the selected container!");
 	public static Text noContainerAccess = Text.parse("&7You cannot access the selected container!");
 	public static Text tooManyShops = Text.parse("&7You have already reached the limit of how many shops you can own!");
 
@@ -465,6 +408,23 @@ public class Messages extends Config {
 	public static Text nameHasNotChanged = Text.parse("&aThe shop's name has not changed.");
 	public static Text nameInvalid = Text.parse("&cInvalid shop name: '&e{name}&c'");
 	public static String nameplatePrefix = c("&2");
+
+	// Members:
+	public static Text typeMemberName = Text.parse("&aPlease enter the player name to add as a member in chat.\n"
+			+ "  &aEnter a dash (-) to cancel.");
+	public static Text memberAdded = Text.parse("&a'&e{member}&a' has been added as a member of this shop!");
+	public static Text memberAlreadyAdded = Text.parse("&7'&e{member}&7' is already a member of this shop.");
+	public static Text memberIsOwner = Text.parse("&7The owner cannot be added as a member.");
+	public static Text memberRemoved = Text.parse("&a'&e{member}&a' has been removed from this shop's members.");
+	public static Text memberNotFound = Text.parse("&7'&e{member}&7' is not a member of this shop.");
+	public static Text memberLimitReached = Text.parse("&7This shop has reached the maximum number of members!");
+	public static Text memberPlayerNotFound = Text.parse("&7Could not find player '&e{player}&7'.");
+	public static Text membersListHeader = Text.parse("&6Members of this shop:");
+	public static Text membersListEntry = Text.parse("&e  - {member}");
+	public static Text membersListEmpty = Text.parse("&7This shop has no members.");
+	public static Text typeRemoveMemberName = Text
+			.parse("&aPlease enter the player name to remove from members in chat.\n"
+					+ "  &aEnter a dash (-) to cancel.");
 
 	public static Text clickNewShopLocation = Text.parse("&aPlease right-click the shop's new location.\n"
 			+ "  &aLeft-click to abort.");
@@ -484,13 +444,17 @@ public class Messages extends Config {
 	public static Text notOwner = Text.parse("&7You are not the owner of this shopkeeper.");
 	// Placeholders: {owner} -> new owners name
 	public static Text ownerSet = Text.parse("&aThe new owner is now &e{owner}");
-	public static Text shopCreationItemsGiven = Text.parse("&aPlayer &e{player}&a has received &e{amount}&a shop creation item(s)!");
+	public static Text shopCreationItemsGiven = Text
+			.parse("&aPlayer &e{player}&a has received &e{amount}&a shop creation item(s)!");
 	public static Text shopCreationItemsReceived = Text.parse("&aYou have received &e{amount}&a shop creation item(s)!");
 	public static Text unknownCurrency = Text.parse("&cUnknown currency: '&e{currency}&c'");
-	public static Text currencyItemsGiven = Text.parse("&aPlayer &e{player}&a has received &6{amount}x&a currency item '&e{currency}&a'!");
-	public static Text currencyItemsReceived = Text.parse("&aYou have received &6{amount}x&a currency item '&e{currency}&a'!");
+	public static Text currencyItemsGiven = Text
+			.parse("&aPlayer &e{player}&a has received &6{amount}x&a currency item '&e{currency}&a'!");
+	public static Text currencyItemsReceived = Text
+			.parse("&aYou have received &6{amount}x&a currency item '&e{currency}&a'!");
 	public static Text mustHoldItemInMainHand = Text.parse("&7You must hold an item in your main hand.");
-	public static Text currencyItemSetToMainHandItem = Text.parse("&aThe currency item '&e{currencyId}&a' has been set to the &eitem in your main hand&a!");
+	public static Text currencyItemSetToMainHandItem = Text
+			.parse("&aThe currency item '&e{currencyId}&a' has been set to the &eitem in your main hand&a!");
 	public static Text itemsUpdated = Text.parse("&aUpdated &e{count}&a item(s)!");
 	public static String unknownBookAuthor = c("Unknown");
 
@@ -509,36 +473,57 @@ public class Messages extends Config {
 	public static Text hired = Text.parse("&aYou have hired this shopkeeper!");
 	public static Text missingHirePerm = Text.parse("&7You do not have the permission to hire shopkeepers.");
 	public static Text cannotHire = Text.parse("&7You cannot afford to hire this shopkeeper.");
-	public static Text cannotHireShopType = Text.parse("&7You do not have the permission to hire this type of shopkeeper.");
+	public static Text cannotHireShopType = Text
+			.parse("&7You do not have the permission to hire this type of shopkeeper.");
 	// Placeholders: {costs}, {hire-item}
-	public static Text villagerForHire = Text.parse("&aThe villager offered his services as a shopkeeper in exchange for &6{costs}x {hire-item}&a.");
+	public static Text villagerForHire = Text
+			.parse("&aThe villager offered his services as a shopkeeper in exchange for &6{costs}x {hire-item}&a.");
 
 	public static Text missingTradePerm = Text.parse("&7You do not have the permission to trade with this shop.");
 	public static Text missingCustomTradePerm = Text.parse("&7You do not have the permission to trade with this shop.");
 	public static Text shopCurrentlyClosed = Text.parse("&7This shop is currently closed. Check again later!");
 	public static Text cannotTradeNoOffers = Text.parse("&7This shop currently has no offers. Check again later!");
-	public static String noOffersOpenEditorDescription = c("&eYou can edit this shop by right clicking it while sneaking.");
+	public static String noOffersOpenEditorDescription = c(
+			"&eYou can edit this shop by right clicking it while sneaking.");
 	public static Text cannotTradeWithOwnShop = Text.parse("&7You cannot trade with your own shop.");
-	public static Text cannotTradeWhileOwnerOnline = Text.parse("&7You cannot trade while the owner of this shop ('&e{owner}&7') is online.");
-	public static Text cannotTradeWithShopMissingContainer = Text.parse("&7You cannot trade with this shop, because its container is missing.");
-	public static Text cannotTradeUnexpectedTrade = Text.parse("&7Trade aborted: The traded items do not match what this shopkeeper expected.");
-	public static Text cannotTradeItemsNotStrictlyMatching = Text.parse("&7Trade aborted: The offered items do not exactly match the required items.");
-	public static Text cannotTradeInsufficientStorageSpace = Text.parse("&7Trade aborted: This shop does not have enough storage space.");
-	public static Text cannotTradeInsufficientCurrency = Text.parse("&7Trade aborted: This shop does not have enough currency.");
-	public static Text cannotTradeInsufficientStock = Text.parse("&7Trade aborted: This shop does not have enough of the traded item.");
-	public static Text cannotTradeInsufficientWritableBooks = Text.parse("&7Trade aborted: This book shop lacks writable books to copy the book with.");
+	public static Text cannotTradeWhileOwnerOnline = Text
+			.parse("&7You cannot trade while the owner of this shop ('&e{owner}&7') is online.");
+	public static Text cannotTradeWithShopMissingContainer = Text
+			.parse("&7You cannot trade with this shop, because its container is missing.");
+	public static Text cannotTradeUnexpectedTrade = Text
+			.parse("&7Trade aborted: The traded items do not match what this shopkeeper expected.");
+	public static Text cannotTradeItemsNotStrictlyMatching = Text
+			.parse("&7Trade aborted: The offered items do not exactly match the required items.");
+	public static Text cannotTradeInsufficientStorageSpace = Text
+			.parse("&7Trade aborted: This shop does not have enough storage space.");
+	public static Text cannotTradeInsufficientCurrency = Text
+			.parse("&7Trade aborted: This shop does not have enough currency.");
+	public static Text cannotTradeInsufficientStock = Text
+			.parse("&7Trade aborted: This shop does not have enough of the traded item.");
+	public static Text cannotTradeInsufficientWritableBooks = Text
+			.parse("&7Trade aborted: This book shop lacks writable books to copy the book with.");
 
-	// Trade placeholders: {player}, {playerId}, {resultItem}, {resultItemAmount}, {item1},
-	// {item1Amount}, {item2}, {item2Amount}, {shop} (replaced by admin or player shop text
-	// respectively), {trade_count} (replaced by the trade count message, or empty if the trade
+	// Trade placeholders: {player}, {playerId}, {resultItem}, {resultItemAmount},
+	// {item1},
+	// {item1Amount}, {item2}, {item2Amount}, {shop} (replaced by admin or player
+	// shop text
+	// respectively), {trade_count} (replaced by the trade count message, or empty
+	// if the trade
 	// count is one).
-	// Shop placeholders: {shop_id}, {shop_uuid}, {shop_name}, {shop_world}, {shop_x}, {shop_y},
-	// {shop_z}, {shop_location} ('world,x,y,z' or '[virtual]'), {shop_type}, {shop_object_type},
-	// {shop_owner_name}, {shop_owner_uuid}. World name and coordinates are empty for virtual shops.
-	public static Text tradeNotificationOneItem = Text.parse("&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
-	public static Text tradeNotificationTwoItems = Text.parse("&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
-	public static Text buyNotificationOneItem = Text.parse("&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
-	public static Text buyNotificationTwoItems = Text.parse("&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
+	// Shop placeholders: {shop_id}, {shop_uuid}, {shop_name}, {shop_world},
+	// {shop_x}, {shop_y},
+	// {shop_z}, {shop_location} ('world,x,y,z' or '[virtual]'), {shop_type},
+	// {shop_object_type},
+	// {shop_owner_name}, {shop_owner_uuid}. World name and coordinates are empty
+	// for virtual shops.
+	public static Text tradeNotificationOneItem = Text.parse(
+			"&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
+	public static Text tradeNotificationTwoItems = Text.parse(
+			"&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
+	public static Text buyNotificationOneItem = Text.parse(
+			"&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
+	public static Text buyNotificationTwoItems = Text.parse(
+			"&7Trade: &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count}");
 	public static Text tradeNotificationPlayerShop = Text.parse("&e{shop_owner_name}");
 	public static Text tradeNotificationNamedPlayerShop = Text.parse("&e{shop_owner_name}");
 	public static Text tradeNotificationAdminShop = Text.parse("&eAdmin Shop");
@@ -546,19 +531,25 @@ public class Messages extends Config {
 	public static Text tradeNotificationTradeCount = Text.parse("&7 (&6{count}x&7)");
 
 	// Placeholders: Same as the general trade notification messages.
-	public static Text ownerTradeNotificationOneItem = Text.parse("&e{player}&7 bought &6{resultItemAmount}x &a{resultItem}&7 from {shop}{trade_count}");
-	public static Text ownerTradeNotificationTwoItems = Text.parse("&e{player}&7 bought &6{resultItemAmount}x &a{resultItem}&7 from {shop}{trade_count}");
-	public static Text ownerBuyNotificationOneItem = Text.parse("&e{player}&7 sold &6{item1Amount}x &a{item1}&7 to {shop}{trade_count}");
-	public static Text ownerBuyNotificationTwoItems = Text.parse("&e{player}&7 sold &6{item1Amount}x &a{item1}&7 and &6{item2Amount}x &a{item2}&7 to {shop}{trade_count}");
+	public static Text ownerTradeNotificationOneItem = Text
+			.parse("&e{player}&7 bought &6{resultItemAmount}x &a{resultItem}&7 from {shop}{trade_count}");
+	public static Text ownerTradeNotificationTwoItems = Text
+			.parse("&e{player}&7 bought &6{resultItemAmount}x &a{resultItem}&7 from {shop}{trade_count}");
+	public static Text ownerBuyNotificationOneItem = Text
+			.parse("&e{player}&7 sold &6{item1Amount}x &a{item1}&7 to {shop}{trade_count}");
+	public static Text ownerBuyNotificationTwoItems = Text
+			.parse("&e{player}&7 sold &6{item1Amount}x &a{item1}&7 and &6{item2Amount}x &a{item2}&7 to {shop}{trade_count}");
 	public static Text ownerTradeNotificationShop = Text.parse("one of your shops");
 	public static Text ownerTradeNotificationNamedShop = Text.parse("your shop &e\"{shop_name}\"");
 	public static Text ownerBuyNotificationShop = Text.parse("one of your shops");
 	public static Text ownerBuyNotificationNamedShop = Text.parse("your shop &e\"{shop_name}\"");
 	public static Text ownerTradeNotificationTradeCount = Text.parse("&7 (&6{count}x&7)");
 
-	public static Text disableTradeNotificationsHint = Text.parse("&7You can disable these trade notifications with the command &e{command}");
+	public static Text disableTradeNotificationsHint = Text
+			.parse("&7You can disable these trade notifications with the command &e{command}");
 	public static Text disableTradeNotificationsHintCommand = Text.parse("/shopkeeper notify trades");
-	public static Text tradeNotificationsDisabled = Text.parse("&aYou will no longer receive trade notifications during this game session.");
+	public static Text tradeNotificationsDisabled = Text
+			.parse("&aYou will no longer receive trade notifications during this game session.");
 	public static Text tradeNotificationsEnabled = Text.parse("&aYou will now receive trade notifications again.");
 
 	public static Text shopkeeperCreated = Text.parse("&aShopkeeper created: &6{type} &7({description})\n{setupDesc}");
@@ -578,15 +569,13 @@ public class Messages extends Config {
 			"Has unlimited stock.",
 			"Insert items from your inventory.",
 			"Top row: Result items",
-			"Bottom rows: Cost items"
-	));
+			"Bottom rows: Cost items"));
 	public static List<String> tradeSetupDescSelling = c(Arrays.asList(
 			"Sells items to players.",
 			"Insert items to sell into the container.",
 			"Left/Right click to adjust amounts.",
 			"Top row: Items being sold",
-			"Bottom rows: Cost items"
-	));
+			"Bottom rows: Cost items"));
 	public static List<String> tradeSetupDescBuying = c(Arrays.asList(
 			"Buys items from players.",
 			"Insert one of each item you want to",
@@ -594,132 +583,110 @@ public class Messages extends Config {
 			"into the container.",
 			"Left/Right click to adjust amounts.",
 			"Top row: Cost items",
-			"Bottom row: Items being bought"
-	));
+			"Bottom row: Items being bought"));
 	public static List<String> tradeSetupDescTrading = c(Arrays.asList(
 			"Trades items with players.",
 			"Pickup an item from your inventory",
 			"and then click a slot to place it.",
 			"Left/Right click to adjust amounts.",
 			"Top row: Result items",
-			"Bottom rows: Cost items"
-	));
+			"Bottom rows: Cost items"));
 	public static List<String> tradeSetupDescBook = c(Arrays.asList(
 			"Sells book copies.",
 			"Insert written and blank books",
 			"into the container.",
 			"Left/Right click to adjust costs.",
 			"Top row: Books being sold",
-			"Bottom rows: Cost items"
-	));
+			"Bottom rows: Cost items"));
 
 	public static String sellingShop_emptyTrade_resultItem = c("&dSell Item");
 	public static List<String> sellingShop_emptyTrade_resultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
 			"Add items to the shop container.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String sellingShop_emptyTrade_item1 = c("&dBuy Item");
 	public static List<String> sellingShop_emptyTrade_item1Lore = c(Arrays.asList(
 			"The item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String sellingShop_emptyTrade_item2 = c("&dBuy Item 2");
 	public static List<String> sellingShop_emptyTrade_item2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String sellingShop_emptyItem1 = c("&dBuy Item");
 	public static List<String> sellingShop_emptyItem1Lore = c(Arrays.asList(
 			"The item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String sellingShop_emptyItem2 = c("&dBuy Item 2");
 	public static List<String> sellingShop_emptyItem2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 
 	public static String buyingShop_emptyTrade_resultItem = c("&dSell Item");
 	public static List<String> buyingShop_emptyTrade_resultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String buyingShop_emptyTrade_item1 = c("&dBuy Item");
 	public static List<String> buyingShop_emptyTrade_item1Lore = c(Arrays.asList(
 			"The item you want to buy.",
 			"Add items to the shop container.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String buyingShop_emptyResultItem = c("&dSell Item");
 	public static List<String> buyingShop_emptyResultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 
 	public static String tradingShop_emptyTrade_resultItem = c("&dSell Item");
 	public static List<String> tradingShop_emptyTrade_resultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
 			"Add items to the shop container,",
 			"or place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String tradingShop_emptyTrade_item1 = c("&dBuy Item");
 	public static List<String> tradingShop_emptyTrade_item1Lore = c(Arrays.asList(
 			"The item you want to buy.",
 			"Place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String tradingShop_emptyTrade_item2 = c("&dBuy Item 2");
 	public static List<String> tradingShop_emptyTrade_item2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
 			"Place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String tradingShop_emptyResultItem = c("&dSell Item");
 	public static List<String> tradingShop_emptyResultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
 			"Place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String tradingShop_emptyItem1 = c("&dBuy Item");
 	public static List<String> tradingShop_emptyItem1Lore = c(Arrays.asList(
 			"The item you want to buy.",
 			"Place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String tradingShop_emptyItem2 = c("&dBuy Item 2");
 	public static List<String> tradingShop_emptyItem2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
 			"Place an item from your inventory.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 
 	public static String bookShop_emptyTrade_resultItem = c("&dSell Item");
 	public static List<String> bookShop_emptyTrade_resultItemLore = c(Arrays.asList(
 			"The item you want to sell.",
-			"Add written books to the shop container."
-	));
+			"Add written books to the shop container."));
 	public static String bookShop_emptyTrade_item1 = c("&dBuy Item");
 	public static List<String> bookShop_emptyTrade_item1Lore = c(Arrays.asList(
 			"The item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String bookShop_emptyTrade_item2 = c("&dBuy Item 2");
 	public static List<String> bookShop_emptyTrade_item2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String bookShop_emptyItem1 = c("&dBuy Item");
 	public static List<String> bookShop_emptyItem1Lore = c(Arrays.asList(
 			"The item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 	public static String bookShop_emptyItem2 = c("&dBuy Item 2");
 	public static List<String> bookShop_emptyItem2Lore = c(Arrays.asList(
 			"The second item you want to buy.",
-			"Left/Right click to adjust the amount."
-	));
+			"Left/Right click to adjust the amount."));
 
 	public static String shopInformationHeader = c("&6Details");
 	public static List<String> shopInformation = c(Arrays.asList(
@@ -728,14 +695,13 @@ public class Messages extends Config {
 			"Name: &e{shop_name}",
 			"Type: &e{shop_type}",
 			"Object: &e{shop_object_type}",
-			"Location: &e{shop_location}"
-	));
+			"Location: &e{shop_location}"));
 	public static List<String> playerShopInformation = c(Arrays.asList(
-			"Owner: &e{shop_owner_name} &8({shop_owner_uuid})"
-	));
+			"Owner: &e{shop_owner_name} &8({shop_owner_uuid})"));
 
 	public static Text missingEditVillagersPerm = Text.parse("&7You do not have the permission to edit villagers.");
-	public static Text missingEditWanderingTradersPerm = Text.parse("&7You do not have the permission to edit wandering traders.");
+	public static Text missingEditWanderingTradersPerm = Text
+			.parse("&7You do not have the permission to edit wandering traders.");
 	public static Text mustTargetEntity = Text.parse("&7You have to target an entity.");
 	public static Text mustTargetVillager = Text.parse("&7You have to target a villager.");
 	public static Text targetEntityIsNoVillager = Text.parse("&7The targeted entity is no regular villager.");
@@ -747,42 +713,35 @@ public class Messages extends Config {
 			"Top row: Result items",
 			"Bottom rows: Cost items",
 			"Edited trades have infinite",
-			"uses and no XP rewards."
-	));
+			"uses and no XP rewards."));
 
 	public static String villagerEditorInformationHeader = c("&6Details");
 	public static List<String> villagerEditorInformation = c(Arrays.asList(
 			"Id: &e{entity_id}",
 			"Unique id: &e{entity_uuid}",
 			"Name: &e{entity_name}",
-			"Location: &e{entity_location}"
-	));
+			"Location: &e{entity_location}"));
 
 	public static String buttonDeleteVillager = c("&4Delete");
 	public static List<String> buttonDeleteVillagerLore = c(Arrays.asList(
-			"Deletes the villager"
-	));
+			"Deletes the villager"));
 	public static String buttonNameVillager = c("&aSet villager name");
 	public static List<String> buttonNameVillagerLore = c(Arrays.asList(
 			"Lets you rename",
-			"the villager"
-	));
+			"the villager"));
 	public static String buttonVillagerInventory = c("&aView villager inventory");
 	public static List<String> buttonVillagerInventoryLore = c(Arrays.asList(
 			"Lets you view a copy of",
-			"the villager's inventory"
-	));
+			"the villager's inventory"));
 	public static String buttonMobAi = c("&aToggle mob AI");
 	public static List<String> buttonMobAiLore = c(Arrays.asList(
-			"Toggles the mob's AI"
-	));
+			"Toggles the mob's AI"));
 	public static String buttonInvulnerability = c("&aToggle invulnerability");
 	public static List<String> buttonInvulnerabilityLore = c(Arrays.asList(
 			"Toggles the mob's",
 			"invulnerability.",
 			"Players in creative mode",
-			"can still damage the mob."
-	));
+			"can still damage the mob."));
 
 	public static String villagerInventoryTitle = c("Villager inventory (copy)");
 	public static String setVillagerXp = c("&aSet the villager's XP to &e{xp}");
@@ -797,15 +756,20 @@ public class Messages extends Config {
 	public static Text noShopsFound = Text.parse("&7No shops were found.");
 
 	public static Text teleportVirtualShopkeeper = Text.parse("&7Cannot teleport to a virtual shopkeeper!");
-	public static Text teleportShopkeeperWorldNotLoaded = Text.parse("&7Cannot teleport to a shopkeeper in an unloaded world!");
+	public static Text teleportShopkeeperWorldNotLoaded = Text
+			.parse("&7Cannot teleport to a shopkeeper in an unloaded world!");
 	public static Text teleportNoSafeLocationFound = Text.parse("&7Could not find a safe location to teleport to!");
 	public static Text teleportFailed = Text.parse("&7The teleport failed!");
 	public static Text teleportSuccess = Text.parse("&aPlayer '&e{player}&a' was teleported to shopkeeper '&e{shop}&a'!");
 
-	public static Text listAdminShopsHeader = Text.parse("&9There are &e{shopsCount} &9admin shops: &e(Page {page} of {maxPage})");
-	public static Text listAllShopsHeader = Text.parse("&9There are &e{shopsCount} &9shops in total: &e(Page {page} of {maxPage})");
-	public static Text listPlayerShopsHeader = Text.parse("&9Player '&e{player}&9' has &e{shopsCount} &9shops: &e(Page {page} of {maxPage})");
-	public static Text listShopsEntry = Text.parse("  &e{shopId}) &7{shopName}&r&8at &7({location})&8, type: &7{shopType}&8, object: &7{objectType}");
+	public static Text listAdminShopsHeader = Text
+			.parse("&9There are &e{shopsCount} &9admin shops: &e(Page {page} of {maxPage})");
+	public static Text listAllShopsHeader = Text
+			.parse("&9There are &e{shopsCount} &9shops in total: &e(Page {page} of {maxPage})");
+	public static Text listPlayerShopsHeader = Text
+			.parse("&9Player '&e{player}&9' has &e{shopsCount} &9shops: &e(Page {page} of {maxPage})");
+	public static Text listShopsEntry = Text
+			.parse("  &e{shopId}) &7{shopName}&r&8at &7({location})&8, type: &7{shopType}&8, object: &7{objectType}");
 
 	public static Text shopRemoved = Text.parse("&aThe shopkeeper has been removed.");
 	public static Text shopAlreadyRemoved = Text.parse("&7The shopkeeper has already been removed.");
@@ -813,16 +777,22 @@ public class Messages extends Config {
 	public static Text shopRemovalCancelled = Text.parse("&cA plugin has prevented the removal of the shopkeeper.");
 
 	public static Text shopsAlreadyRemoved = Text.parse("&e{shopsCount}&7 of the shops have already been removed.");
-	public static Text shopRemovalsCancelled = Text.parse("&cPlugins have prevented the removal of &e{shopsCount}&c of the shops.");
+	public static Text shopRemovalsCancelled = Text
+			.parse("&cPlugins have prevented the removal of &e{shopsCount}&c of the shops.");
 	public static Text adminShopsRemoved = Text.parse("&e{shopsCount} &aadmin shops have been removed.");
-	public static Text shopsOfPlayerRemoved = Text.parse("&e{shopsCount} &ashops of player '&e{player}&a' have been removed.");
+	public static Text shopsOfPlayerRemoved = Text
+			.parse("&e{shopsCount} &ashops of player '&e{player}&a' have been removed.");
 	public static Text playerShopsRemoved = Text.parse("&e{shopsCount} &aplayer shops have been removed.");
 
 	public static Text confirmRemoveShop = Text.parse("&cYou are about to irrevocably remove the specified shopkeeper!");
-	public static Text confirmRemoveAllAdminShops = Text.parse("&cYou are about to irrevocably remove all admin shops (&6{shopsCount}&c)!");
-	public static Text confirmRemoveAllOwnShops = Text.parse("&cYou are about to irrevocably remove all your shops (&6{shopsCount}&c)!");
-	public static Text confirmRemoveAllShopsOfPlayer = Text.parse("&cYou are about to irrevocably remove all shops of player &6{player}&c (&6{shopsCount}&c)!");
-	public static Text confirmRemoveAllPlayerShops = Text.parse("&cYou are about to irrevocably remove all player shops of all players (&6{shopsCount}&c)!");
+	public static Text confirmRemoveAllAdminShops = Text
+			.parse("&cYou are about to irrevocably remove all admin shops (&6{shopsCount}&c)!");
+	public static Text confirmRemoveAllOwnShops = Text
+			.parse("&cYou are about to irrevocably remove all your shops (&6{shopsCount}&c)!");
+	public static Text confirmRemoveAllShopsOfPlayer = Text
+			.parse("&cYou are about to irrevocably remove all shops of player &6{player}&c (&6{shopsCount}&c)!");
+	public static Text confirmRemoveAllPlayerShops = Text
+			.parse("&cYou are about to irrevocably remove all player shops of all players (&6{shopsCount}&c)!");
 
 	public static Text confirmReplaceAllShopsWithVanillaVillagers = Text.parse(
 			"&cYou are about to irrevocably delete all shops (&6{shopsCount}&c) and replace them with vanilla villagers without AI!\n"
@@ -838,41 +808,47 @@ public class Messages extends Config {
 	public static String confirmationUiDeleteShopTitle = c("&cReally delete this shop?");
 	public static List<String> confirmationUiDeleteShopConfirmLore = c(Arrays.asList(
 			"This will irrevocably",
-			"remove this shop!"
-	));
+			"remove this shop!"));
 
 	public static String confirmationUiDeleteVillagerTitle = c("&cReally delete this villager?");
 	public static List<String> confirmationUiDeleteVillagerConfirmLore = c(Arrays.asList(
 			"This will irrevocably",
-			"remove this villager!"
-	));
+			"remove this villager!"));
 	public static Text villagerRemoved = Text.parse("&aThe villager has been removed.");
 
 	public static String confirmationUiConfirm = c("&2Confirm");
 	public static String confirmationUiCancel = c("&4Cancel");
 	public static List<String> confirmationUiCancelLore = c(Arrays.asList(
 			"This will abort the",
-			"current action."
-	));
+			"current action."));
 	public static Text confirmationUiAborted = Text.parse("&7Confirmation aborted.");
 
-	public static Text snapshotListHeader = Text.parse("&9Shop &e{shop_id} &9has &e{snapshotsCount} &9snapshots: &e(Page {page} of {maxPage})");
+	public static Text snapshotListHeader = Text
+			.parse("&9Shop &e{shop_id} &9has &e{snapshotsCount} &9snapshots: &e(Page {page} of {maxPage})");
 	public static Text snapshotListEntry = Text.parse("  &e{id}) &2{name}&8 (&7{timestamp}&8)");
 	public static Text invalidSnapshotId = Text.parse("&cInvalid snapshot id: &e{argument}");
 	public static Text invalidSnapshotName = Text.parse("&cNo snapshot found with name '&e{argument}&c'.");
-	public static Text snapshotNameTooLong = Text.parse("&cThe snapshot name can be a maximum of &e{maxLength}&c characters long: &e{name}");
+	public static Text snapshotNameTooLong = Text
+			.parse("&cThe snapshot name can be a maximum of &e{maxLength}&c characters long: &e{name}");
 	public static Text snapshotNameInvalid = Text.parse("&cInvalid snapshot name: &e{name}");
-	public static Text snapshotNameAlreadyExists = Text.parse("&cThere already exists another snapshot with this name: &e{name}");
+	public static Text snapshotNameAlreadyExists = Text
+			.parse("&cThere already exists another snapshot with this name: &e{name}");
 	public static Text snapshotCreated = Text.parse("&aNew snapshot created: &e({id}) &2{name} &8(&7{timestamp}&8)");
-	public static Text confirmRemoveSnapshot = Text.parse("&cYou are about to irrevocably delete the specified snapshot!");
-	public static Text confirmRemoveAllSnapshots = Text.parse("&cYou are about to irrevocably delete all snapshots of the specified shopkeeper (&6{snapshotsCount}&c)!");
-	public static Text actionAbortedSnapshotsChanged = Text.parse("&cAction aborted! The snapshots have changed in the meantime. Try again.");
+	public static Text confirmRemoveSnapshot = Text
+			.parse("&cYou are about to irrevocably delete the specified snapshot!");
+	public static Text confirmRemoveAllSnapshots = Text
+			.parse("&cYou are about to irrevocably delete all snapshots of the specified shopkeeper (&6{snapshotsCount}&c)!");
+	public static Text actionAbortedSnapshotsChanged = Text
+			.parse("&cAction aborted! The snapshots have changed in the meantime. Try again.");
 	public static Text snapshotRemoved = Text.parse("&aSnapshot deleted: &e({id}) &2{name} &8(&7{timestamp}&8)");
-	public static Text snapshotRemovedAll = Text.parse("&aAll &e{snapshotsCount} &asnapshots of shop &e{shop_id}&a have been deleted.");
-	public static Text snapshotRestoreFailed = Text.parse("&cFailed to restore snapshot: &e({id}) &2{name} &8(&7{timestamp}&8)");
+	public static Text snapshotRemovedAll = Text
+			.parse("&aAll &e{snapshotsCount} &asnapshots of shop &e{shop_id}&a have been deleted.");
+	public static Text snapshotRestoreFailed = Text
+			.parse("&cFailed to restore snapshot: &e({id}) &2{name} &8(&7{timestamp}&8)");
 	public static Text snapshotRestored = Text.parse("&aSnapshot restored: &e({id}) &2{name} &8(&7{timestamp}&8)");
 
-	public static Text historyHeader = Text.parse("&9Trades of {players}&9 with {shops}&9: &e{tradesCount} &e(Page {page} of {maxPage})");
+	public static Text historyHeader = Text
+			.parse("&9Trades of {players}&9 with {shops}&9: &e{tradesCount} &e(Page {page} of {maxPage})");
 	public static Text historyHeaderAllPlayers = Text.parse("&eall players");
 	public static Text historyHeaderSpecificPlayer = Text.parse("&e{player}");
 	public static Text historyHeaderAllShops = Text.parse("&eall shops");
@@ -885,8 +861,10 @@ public class Messages extends Config {
 	public static Text historyDisabled = Text.parse("&7The trading history is disabled.");
 	public static Text historyNoTradesFound = Text.parse("&7No trades found.");
 
-	public static Text historyEntryOneItem = Text.parse("  &f{index}) &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count} &7(&f{timeAgo} ago&7)");
-	public static Text historyEntryTwoItems = Text.parse("  &f{index}) &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count} &7(&f{timeAgo} ago&7)");
+	public static Text historyEntryOneItem = Text.parse(
+			"  &f{index}) &e{player}&7 [&6{item1Amount}x &a{item1}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count} &7(&f{timeAgo} ago&7)");
+	public static Text historyEntryTwoItems = Text.parse(
+			"  &f{index}) &e{player}&7 [&6{item1Amount}x &a{item1}&7] [&6{item2Amount}x &a{item2}&7] \u279e [&6{resultItemAmount}x &a{resultItem}&7] {shop}{trade_count} &7(&f{timeAgo} ago&7)");
 	public static Text historyEntryPlayerShop = Text.parse("&e{owner}");
 	public static Text historyEntryAdminShop = Text.parse("&eAdmin Shop");
 	public static Text historyEntryTradeCount = Text.parse("&7 (&6{count}x&7)");
@@ -897,26 +875,32 @@ public class Messages extends Config {
 
 	public static Text commandUnknown = Text.parse("&cUnknown command '&e{command}&c'!");
 	public static Text commandArgumentUnexpected = Text.parse("&cUnexpected argument '&e{argument}&c'.");
-	public static Text commandArgumentRequiresPlayer = Text.parse("&cArgument '&e{argumentFormat}&c' requires a player to execute the command.");
+	public static Text commandArgumentRequiresPlayer = Text
+			.parse("&cArgument '&e{argumentFormat}&c' requires a player to execute the command.");
 	public static Text commandArgumentMissing = Text.parse("&cMissing argument '&e{argumentFormat}&c'.");
 	public static Text commandArgumentInvalid = Text.parse("&cInvalid argument '&e{argument}&c'.");
 	public static Text commandPlayerArgumentMissing = Text.parse("&cNo player specified for '&e{argumentFormat}&c'.");
 	public static Text commandPlayerArgumentInvalid = Text.parse("&cNo player found for '&e{argument}&c'.");
 	public static Text commandShopTypeArgumentInvalid = Text.parse("&cUnknown shop type '&e{argument}&c'.");
 	public static Text commandShopTypeArgumentNoAdminShop = Text.parse("&cShop type '&e{argument}&c' is no admin shop.");
-	public static Text commandShopTypeArgumentNoPlayerShop = Text.parse("&cShop type '&e{argument}&c' is no player shop.");
+	public static Text commandShopTypeArgumentNoPlayerShop = Text
+			.parse("&cShop type '&e{argument}&c' is no player shop.");
 	public static Text commandShopObjectTypeArgumentInvalid = Text.parse("&cUnknown shop object type '&e{argument}&c'.");
 	public static Text commandShopkeeperArgumentInvalid = Text.parse("&cNo shopkeeper found for '&e{argument}&c'.");
-	public static Text commandShopkeeperArgumentNoAdminShop = Text.parse("&cShopkeeper '&e{argument}&c' is no admin shopkeeper.");
-	public static Text commandShopkeeperArgumentNoPlayerShop = Text.parse("&cShopkeeper '&e{argument}&c' is no player shopkeeper.");
-	public static Text commandShopkeeperArgumentNoAccess = Text.parse("&cYou do not have access to shopkeeper '&e{argument}&c'.");
+	public static Text commandShopkeeperArgumentNoAdminShop = Text
+			.parse("&cShopkeeper '&e{argument}&c' is no admin shopkeeper.");
+	public static Text commandShopkeeperArgumentNoPlayerShop = Text
+			.parse("&cShopkeeper '&e{argument}&c' is no player shopkeeper.");
+	public static Text commandShopkeeperArgumentNoAccess = Text
+			.parse("&cYou do not have access to shopkeeper '&e{argument}&c'.");
 	public static Text commandEntityArgumentNoVillager = Text.parse("&cEntity '&e{argument}&c' is no regular villager.");
 
 	public static Text ambiguousPlayerName = Text.parse("&cThere are multiple players for the name '&e{name}&c'!");
 	public static Text ambiguousPlayerNameEntry = Text.parse("&c  - '&e{name}&r&c' (&6{uuid}&c)");
 	public static Text ambiguousPlayerNameMore = Text.parse("&c  - ....");
 
-	public static Text ambiguousShopkeeperName = Text.parse("&cThere are multiple shopkeepers for the name '&e{name}&c'!");
+	public static Text ambiguousShopkeeperName = Text
+			.parse("&cThere are multiple shopkeepers for the name '&e{name}&c'!");
 	public static Text ambiguousShopkeeperNameEntry = Text.parse("&c  - &e{id})&c '&e{name}&r&c' (&6{uuid}&c)");
 	public static Text ambiguousShopkeeperNameMore = Text.parse("&c  - ....");
 
@@ -936,7 +920,8 @@ public class Messages extends Config {
 	public static Text commandDescriptionList = Text.parse("Lists all shops of a specific player, or all admin shops.");
 	public static Text commandDescriptionHistory = Text.parse("Shows the trading history.");
 	public static Text commandDescriptionRemove = Text.parse("Removes a specific shop.");
-	public static Text commandDescriptionRemoveAll = Text.parse("Removes all shops of a specific player, all players, or all admin shops.");
+	public static Text commandDescriptionRemoveAll = Text
+			.parse("Removes all shops of a specific player, all players, or all admin shops.");
 	public static Text commandDescriptionGive = Text.parse("Gives shop creation item(s) to the specified player.");
 	public static Text commandDescriptionGiveCurrency = Text.parse("Gives currency item(s) to the specified player.");
 	public static Text commandDescriptionSetCurrency = Text.parse("Changes the currency item to the item held in hand.");
@@ -945,15 +930,18 @@ public class Messages extends Config {
 	public static Text commandDescriptionRemoteEdit = Text.parse("Remotely edits a shop.");
 	public static Text commandDescriptionTransfer = Text.parse("Transfers the ownership of a shop.");
 	public static Text commandDescriptionTeleport = Text.parse("Teleports to a shop.");
-	public static Text commandDescriptionSettradeperm = Text.parse("Sets, removes (-) or displays (?) the trading permission.");
-	public static Text commandDescriptionSettradedcommand = Text.parse("Sets, removes (-) or displays (?) the traded command of the held item.");
+	public static Text commandDescriptionSettradeperm = Text
+			.parse("Sets, removes (-) or displays (?) the trading permission.");
+	public static Text commandDescriptionSettradedcommand = Text
+			.parse("Sets, removes (-) or displays (?) the traded command of the held item.");
 	public static Text commandDescriptionSetforhire = Text.parse("Sets one of your shops for sale.");
 	public static Text commandDescriptionSnapshotList = Text.parse("Lists the snapshots of a shop.");
 	public static Text commandDescriptionSnapshotCreate = Text.parse("Creates a new shop snapshot.");
 	public static Text commandDescriptionSnapshotRemove = Text.parse("Removes a specific or all snapshots of a shop.");
 	public static Text commandDescriptionSnapshotRestore = Text.parse("Restores a specific shop snapshot.");
 	public static Text commandDescriptionEditVillager = Text.parse("Opens the editor for the target villager.");
-	public static Text commandDescriptionReplaceAllWithVanillaVillagers = Text.parse("Replaces all shopkeepers with vanilla villagers without AI.");
+	public static Text commandDescriptionReplaceAllWithVanillaVillagers = Text
+			.parse("Replaces all shopkeepers with vanilla villagers without AI.");
 
 	/////
 
@@ -983,7 +971,8 @@ public class Messages extends Config {
 	}
 
 	/**
-	 * The default language file is freshly written on every startup and overwrites the already
+	 * The default language file is freshly written on every startup and overwrites
+	 * the already
 	 * existing default language file.
 	 */
 	private static void saveDefaultLanguageFile() {

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/members/ShopkeeperMembers.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/members/ShopkeeperMembers.java
@@ -1,0 +1,170 @@
+package com.nisovin.shopkeepers.members;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+import com.nisovin.shopkeepers.api.events.ShopkeeperEditedEvent;
+import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
+import com.nisovin.shopkeepers.api.user.User;
+import com.nisovin.shopkeepers.input.InputRequest;
+import com.nisovin.shopkeepers.input.chat.ChatInput;
+import com.nisovin.shopkeepers.lang.Messages;
+import com.nisovin.shopkeepers.shopkeeper.player.AbstractPlayerShopkeeper;
+import com.nisovin.shopkeepers.util.bukkit.TextUtils;
+import com.nisovin.shopkeepers.util.java.Validate;
+
+public class ShopkeeperMembers {
+
+  private enum MemberAction {
+    ADD,
+    REMOVE
+  }
+
+  private class MemberInputRequest implements InputRequest<String> {
+
+    private final Player player;
+    private final AbstractPlayerShopkeeper shopkeeper;
+    private final MemberAction action;
+
+    MemberInputRequest(Player player, AbstractPlayerShopkeeper shopkeeper, MemberAction action) {
+      assert player != null && shopkeeper != null && action != null;
+      this.player = player;
+      this.shopkeeper = shopkeeper;
+      this.action = action;
+    }
+
+    @Override
+    public void onInput(String message) {
+      if (!shopkeeper.isValid())
+        return;
+
+      String input = message.trim();
+      if (input.equals("-")) {
+        // Cancelled
+        return;
+      }
+
+      if (action == MemberAction.ADD) {
+        handleAddMember(player, shopkeeper, input);
+      } else {
+        handleRemoveMember(player, shopkeeper, input);
+      }
+    }
+  }
+
+  private final ChatInput chatInput;
+
+  public ShopkeeperMembers(ChatInput chatInput) {
+    Validate.notNull(chatInput, "chatInput is null");
+    this.chatInput = chatInput;
+  }
+
+  public void onEnable() {
+  }
+
+  public void onDisable() {
+  }
+
+  public void startAddMember(Player player, AbstractPlayerShopkeeper shopkeeper) {
+    Validate.notNull(player, "player is null");
+    Validate.notNull(shopkeeper, "shopkeeper is null");
+    chatInput.request(player, new MemberInputRequest(player, shopkeeper, MemberAction.ADD));
+  }
+
+  public void startRemoveMember(Player player, AbstractPlayerShopkeeper shopkeeper) {
+    Validate.notNull(player, "player is null");
+    Validate.notNull(shopkeeper, "shopkeeper is null");
+    chatInput.request(player, new MemberInputRequest(player, shopkeeper, MemberAction.REMOVE));
+  }
+
+  public void abortMemberInput(Player player) {
+    Validate.notNull(player, "player is null");
+    InputRequest<String> request = chatInput.getRequest(player);
+    if (request instanceof MemberInputRequest) {
+      chatInput.abortRequest(player, request);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  private void handleAddMember(Player player, AbstractPlayerShopkeeper shopkeeper, String playerName) {
+    // Try to resolve the player:
+    OfflinePlayer targetPlayer = Bukkit.getOfflinePlayer(playerName);
+    String targetName = targetPlayer.getName();
+    UUID targetUUID = targetPlayer.getUniqueId();
+
+    if (targetName == null) {
+      TextUtils.sendMessage(player, Messages.memberPlayerNotFound, "player", playerName);
+      return;
+    }
+
+    // Check if this is the owner:
+    if (targetUUID.equals(shopkeeper.getOwnerUUID())) {
+      TextUtils.sendMessage(player, Messages.memberIsOwner);
+      return;
+    }
+
+    // Check if already a member:
+    if (shopkeeper.isMember(targetUUID)) {
+      TextUtils.sendMessage(player, Messages.memberAlreadyAdded, "member", targetName);
+      return;
+    }
+
+    // Try to add:
+    boolean added = shopkeeper.addMember(targetUUID, targetName);
+    if (!added) {
+      TextUtils.sendMessage(player, Messages.memberLimitReached);
+      return;
+    }
+
+    TextUtils.sendMessage(player, Messages.memberAdded, "member", targetName);
+
+    // Call event:
+    Bukkit.getPluginManager().callEvent(new ShopkeeperEditedEvent(shopkeeper, player));
+
+    // Save:
+    shopkeeper.save();
+  }
+
+  private void handleRemoveMember(Player player, AbstractPlayerShopkeeper shopkeeper, String playerName) {
+    // Find the member by name:
+    List<? extends User> members = shopkeeper.getMembers();
+    User targetMember = null;
+    for (User member : members) {
+      if (member.getLastKnownName().equalsIgnoreCase(playerName)) {
+        targetMember = member;
+        break;
+      }
+    }
+
+    if (targetMember == null) {
+      TextUtils.sendMessage(player, Messages.memberNotFound, "member", playerName);
+      return;
+    }
+
+    shopkeeper.removeMember(targetMember.getUniqueId());
+    TextUtils.sendMessage(player, Messages.memberRemoved, "member", targetMember.getLastKnownName());
+
+    // Call event:
+    Bukkit.getPluginManager().callEvent(new ShopkeeperEditedEvent(shopkeeper, player));
+
+    // Save:
+    shopkeeper.save();
+  }
+
+  public void listMembers(Player player, PlayerShopkeeper shopkeeper) {
+    List<? extends User> members = shopkeeper.getMembers();
+    if (members.isEmpty()) {
+      TextUtils.sendMessage(player, Messages.membersListEmpty);
+      return;
+    }
+
+    TextUtils.sendMessage(player, Messages.membersListHeader);
+    for (User member : members) {
+      TextUtils.sendMessage(player, Messages.membersListEntry, "member", member.getLastKnownName());
+    }
+  }
+}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/AbstractPlayerShopkeeper.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/AbstractPlayerShopkeeper.java
@@ -1,8 +1,11 @@
 package com.nisovin.shopkeepers.shopkeeper.player;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -25,6 +28,7 @@ import com.nisovin.shopkeepers.api.internal.util.Unsafe;
 import com.nisovin.shopkeepers.api.shopkeeper.ShopCreationData;
 import com.nisovin.shopkeepers.api.shopkeeper.ShopkeeperCreateException;
 import com.nisovin.shopkeepers.api.shopkeeper.TradingRecipe;
+import com.nisovin.shopkeepers.api.shopkeeper.player.MemberPermission;
 import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopCreationData;
 import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
 import com.nisovin.shopkeepers.api.ui.DefaultUITypes;
@@ -55,11 +59,13 @@ import com.nisovin.shopkeepers.util.bukkit.LocationUtils;
 import com.nisovin.shopkeepers.util.bukkit.MutableBlockLocation;
 import com.nisovin.shopkeepers.util.bukkit.TextUtils;
 import com.nisovin.shopkeepers.util.data.container.DataContainer;
+import com.nisovin.shopkeepers.util.data.serialization.java.DataContainerSerializers;
 import com.nisovin.shopkeepers.util.data.property.BasicProperty;
 import com.nisovin.shopkeepers.util.data.property.Property;
 import com.nisovin.shopkeepers.util.data.property.validation.bukkit.ItemStackValidators;
 import com.nisovin.shopkeepers.util.data.property.validation.java.StringValidators;
 import com.nisovin.shopkeepers.util.data.serialization.DataAccessor;
+import com.nisovin.shopkeepers.util.data.serialization.DataSerializer;
 import com.nisovin.shopkeepers.util.data.serialization.InvalidDataException;
 import com.nisovin.shopkeepers.util.data.serialization.bukkit.ItemStackSerializers;
 import com.nisovin.shopkeepers.util.data.serialization.java.BooleanSerializers;
@@ -81,24 +87,27 @@ public abstract class AbstractPlayerShopkeeper
 	private static final int CHECK_CONTAINER_PERIOD_SECONDS = 5;
 	private static final CyclicCounter nextCheckingOffset = new CyclicCounter(
 			1,
-			CHECK_CONTAINER_PERIOD_SECONDS + 1
-	);
+			CHECK_CONTAINER_PERIOD_SECONDS + 1);
 
 	private User owner = SKUser.EMPTY; // Valid after successful initialization
+	private final List<User> members = new ArrayList<>();
+	private final List<? extends User> membersView = Collections.unmodifiableList(members);
 	// The world name of this BlockLocation matches the shopkeeper world name.
-	// TODO Allow the container to be located in a world different to that of the shopkeeper? This
-	// could also be useful for virtual player shops, which don't have a world themselves, but would
+	// TODO Allow the container to be located in a world different to that of the
+	// shopkeeper? This
+	// could also be useful for virtual player shops, which don't have a world
+	// themselves, but would
 	// still need a container block in a world.
 	// Immutable, valid after successful initialization:
 	private BlockLocation container = BlockLocation.EMPTY;
 	private boolean notifyOnTrades = NOTIFY_ON_TRADES.getDefaultValue();
 	private @Nullable UnmodifiableItemStack hireCost = null; // Null if not for hire
 
-	// Initial threshold between [1, CHECK_CONTAINER_PERIOD_SECONDS] for load balancing:
+	// Initial threshold between [1, CHECK_CONTAINER_PERIOD_SECONDS] for load
+	// balancing:
 	private final RateLimiter checkContainerLimiter = new RateLimiter(
 			CHECK_CONTAINER_PERIOD_SECONDS,
-			nextCheckingOffset.getAndIncrement()
-	);
+			nextCheckingOffset.getAndIncrement());
 
 	/**
 	 * Creates a new and not yet initialized {@link AbstractPlayerShopkeeper}.
@@ -135,6 +144,7 @@ public abstract class AbstractPlayerShopkeeper
 	public void loadDynamicState(ShopkeeperData shopkeeperData) throws InvalidDataException {
 		super.loadDynamicState(shopkeeperData);
 		this.loadOwner(shopkeeperData);
+		this.loadMembers(shopkeeperData);
 		this.loadContainer(shopkeeperData);
 		this.loadNotifyOnTrades(shopkeeperData);
 		this.loadForHire(shopkeeperData);
@@ -144,6 +154,7 @@ public abstract class AbstractPlayerShopkeeper
 	public void saveDynamicState(ShopkeeperData shopkeeperData, boolean saveAll) {
 		super.saveDynamicState(shopkeeperData, saveAll);
 		this.saveOwner(shopkeeperData);
+		this.saveMembers(shopkeeperData);
 		this.saveContainer(shopkeeperData);
 		this.saveNotifyOnTrades(shopkeeperData);
 		this.saveForHire(shopkeeperData);
@@ -232,11 +243,15 @@ public abstract class AbstractPlayerShopkeeper
 	protected void onShopkeeperMoved() {
 		super.onShopkeeperMoved();
 
-		// Update the container location and the registered container protection if the shopkeeper
+		// Update the container location and the registered container protection if the
+		// shopkeeper
 		// has been moved to a different world:
-		// The container is (currently) assumed to always be located in the same world as the
-		// shopkeeper. If the shopkeeper is moved to a different world, the container is expected to
-		// also have been moved. Otherwise, if the container cannot be found in the new world,
+		// The container is (currently) assumed to always be located in the same world
+		// as the
+		// shopkeeper. If the shopkeeper is moved to a different world, the container is
+		// expected to
+		// also have been moved. Otherwise, if the container cannot be found in the new
+		// world,
 		// trading will not work.
 		if (!Objects.equals(this.getWorldName(), container.getWorldName())) {
 			// This updates the container's world based on the shopkeeper's current world:
@@ -378,6 +393,150 @@ public abstract class AbstractPlayerShopkeeper
 		return Bukkit.getPlayer(this.getOwnerUUID());
 	}
 
+	// MEMBERS
+
+	private static final Property<UUID> MEMBER_UNIQUE_ID = new BasicProperty<UUID>()
+			.dataKeyAccessor("uuid", UUIDSerializers.LENIENT)
+			.build();
+	private static final Property<String> MEMBER_NAME = new BasicProperty<String>()
+			.dataKeyAccessor("name", StringSerializers.SCALAR)
+			.validator(StringValidators.NON_EMPTY)
+			.build();
+
+	private static final DataSerializer<User> MEMBER_SERIALIZER = new DataSerializer<User>() {
+		@Override
+		public @Nullable Object serialize(User value) {
+			Validate.notNull(value, "value is null");
+			DataContainer data = DataContainer.create();
+			data.set(MEMBER_UNIQUE_ID, value.getUniqueId());
+			data.set(MEMBER_NAME, value.getLastKnownName());
+			return data.serialize();
+		}
+
+		@Override
+		public User deserialize(Object data) throws InvalidDataException {
+			DataContainer memberData = DataContainerSerializers.DEFAULT.deserialize(data);
+			UUID uuid = memberData.get(MEMBER_UNIQUE_ID);
+			String name = memberData.get(MEMBER_NAME);
+			return SKUser.of(uuid, name);
+		}
+	};
+
+	private static final DataSerializer<List<? extends User>> MEMBERS_LIST_SERIALIZER = new DataSerializer<List<? extends User>>() {
+		@Override
+		public @Nullable Object serialize(@ReadOnly List<? extends User> value) {
+			Validate.notNull(value, "value is null");
+			if (value.isEmpty())
+				return null; // Omit empty lists
+			DataContainer listData = DataContainer.create();
+			int id = 1;
+			for (User member : value) {
+				Validate.notNull(member, "list of members contains null");
+				listData.set(String.valueOf(id), MEMBER_SERIALIZER.serialize(member));
+				id++;
+			}
+			return listData.serialize();
+		}
+
+		@Override
+		public List<? extends User> deserialize(Object data) throws InvalidDataException {
+			DataContainer listData = DataContainerSerializers.DEFAULT.deserialize(data);
+			Set<? extends String> keys = listData.getKeys();
+			List<User> members = new ArrayList<>(keys.size());
+			for (String id : keys) {
+				Object memberData = Unsafe.assertNonNull(listData.get(id));
+				User member;
+				try {
+					member = MEMBER_SERIALIZER.deserialize(memberData);
+				} catch (InvalidDataException e) {
+					throw new InvalidDataException("Invalid member " + id + ": "
+							+ e.getMessage(), e);
+				}
+				members.add(member);
+			}
+			return members;
+		}
+	};
+
+	public static final Property<List<? extends User>> MEMBERS = new BasicProperty<List<? extends User>>()
+			.dataKeyAccessor("members", MEMBERS_LIST_SERIALIZER)
+			.useDefaultIfMissing()
+			.defaultValue(Collections.emptyList())
+			.build();
+
+	private void loadMembers(ShopkeeperData shopkeeperData) throws InvalidDataException {
+		assert shopkeeperData != null;
+		this._setMembers(shopkeeperData.get(MEMBERS));
+	}
+
+	private void saveMembers(ShopkeeperData shopkeeperData) {
+		assert shopkeeperData != null;
+		shopkeeperData.set(MEMBERS, membersView);
+	}
+
+	private void _setMembers(@ReadOnly List<? extends User> members) {
+		Validate.notNull(members, "members is null");
+		this.members.clear();
+		this.members.addAll(members);
+	}
+
+	@Override
+	public boolean addMember(UUID memberUUID, String memberName) {
+		Validate.notNull(memberUUID, "memberUUID is null");
+		Validate.notNull(memberName, "memberName is null");
+		Validate.isTrue(!memberName.isEmpty(), "memberName is empty");
+		// Cannot add the owner as a member:
+		if (memberUUID.equals(this.getOwnerUUID()))
+			return false;
+		// Check if already a member:
+		if (this.isMember(memberUUID))
+			return false;
+		// Check member limit:
+		int maxMembers = Settings.maxMembersPerShop;
+		if (maxMembers >= 0 && this.members.size() >= maxMembers)
+			return false;
+
+		this.members.add(SKUser.of(memberUUID, memberName));
+		this.markDirty();
+		return true;
+	}
+
+	@Override
+	public boolean removeMember(UUID memberUUID) {
+		Validate.notNull(memberUUID, "memberUUID is null");
+		boolean removed = this.members.removeIf(user -> user.getUniqueId().equals(memberUUID));
+		if (removed) {
+			this.markDirty();
+		}
+		return removed;
+	}
+
+	@Override
+	public List<? extends User> getMembers() {
+		return membersView;
+	}
+
+	@Override
+	public boolean isMember(Player player) {
+		return this.isMember(player.getUniqueId());
+	}
+
+	@Override
+	public boolean isMember(UUID playerUUID) {
+		Validate.notNull(playerUUID, "playerUUID is null");
+		for (User member : members) {
+			if (member.getUniqueId().equals(playerUUID)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public boolean isOwnerOrMember(Player player) {
+		return this.isOwner(player) || this.isMember(player);
+	}
+
 	// TRADE NOTIFICATIONS
 
 	public static final Property<Boolean> NOTIFY_ON_TRADES = new BasicProperty<Boolean>()
@@ -403,7 +562,8 @@ public abstract class AbstractPlayerShopkeeper
 
 	@Override
 	public void setNotifyOnTrades(boolean notifyOnTrades) {
-		if (this.notifyOnTrades == notifyOnTrades) return;
+		if (this.notifyOnTrades == notifyOnTrades)
+			return;
 		this._setNotifyOnTrades(notifyOnTrades);
 		this.markDirty();
 	}
@@ -423,23 +583,25 @@ public abstract class AbstractPlayerShopkeeper
 
 	static {
 		// Register shopkeeper data migrations:
-		// TODO Can be removed once all servers are expected to have updated to our new item stack
+		// TODO Can be removed once all servers are expected to have updated to our new
+		// item stack
 		// serialization format.
 		ShopkeeperDataMigrator.registerMigration(new Migration(
 				"hire-cost-item",
-				MigrationPhase.ofShopkeeperClass(AbstractPlayerShopkeeper.class)
-		) {
+				MigrationPhase.ofShopkeeperClass(AbstractPlayerShopkeeper.class)) {
 			@Override
 			public boolean migrate(
 					ShopkeeperData shopkeeperData,
-					String logPrefix
-			) throws InvalidDataException {
-				@Nullable UnmodifiableItemStack hireCost = shopkeeperData.get(HIRE_COST_ITEM);
-				if (hireCost == null) return false; // Nothing to migrate
+					String logPrefix) throws InvalidDataException {
+				@Nullable
+				UnmodifiableItemStack hireCost = shopkeeperData.get(HIRE_COST_ITEM);
+				if (hireCost == null)
+					return false; // Nothing to migrate
 				assert !ItemUtils.isEmpty(hireCost);
 
 				boolean itemMigrated = false;
-				@Nullable UnmodifiableItemStack migratedHireCost = ItemMigration.migrateItemStack(hireCost);
+				@Nullable
+				UnmodifiableItemStack migratedHireCost = ItemMigration.migrateItemStack(hireCost);
 				if (!ItemUtils.isSimilar(hireCost, migratedHireCost)) {
 					if (ItemUtils.isEmpty(migratedHireCost)) {
 						throw new InvalidDataException("Hire cost item migration failed: " + hireCost);
@@ -449,7 +611,8 @@ public abstract class AbstractPlayerShopkeeper
 					itemMigrated = true;
 				}
 
-				if (!itemMigrated) return false; // Nothing migrated.
+				if (!itemMigrated)
+					return false; // Nothing migrated.
 
 				// Write back the migrated hire cost item:
 				shopkeeperData.set(HIRE_COST_ITEM, hireCost);
@@ -652,9 +815,11 @@ public abstract class AbstractPlayerShopkeeper
 	public int getCurrencyInContainer() {
 		int totalCurrency = 0;
 		// Empty if the container is not found:
-		@Nullable ItemStack[] contents = this.getContainerContents();
+		@Nullable
+		ItemStack[] contents = this.getContainerContents();
 		for (ItemStack itemStack : contents) {
-			if (itemStack == null) continue;
+			if (itemStack == null)
+				continue;
 			Currency currency = Currencies.match(itemStack);
 			if (currency != null) {
 				totalCurrency += (itemStack.getAmount() * currency.getValue());
@@ -663,13 +828,13 @@ public abstract class AbstractPlayerShopkeeper
 		return totalCurrency;
 	}
 
-	// Returns null (and logs a warning) if the price cannot be represented correctly by currency
+	// Returns null (and logs a warning) if the price cannot be represented
+	// correctly by currency
 	// items.
 	protected final @Nullable TradingRecipe createSellingRecipe(
 			UnmodifiableItemStack itemBeingSold,
 			int price,
-			boolean outOfStock
-	) {
+			boolean outOfStock) {
 		Validate.notNull(itemBeingSold, "itemBeingSold is null");
 		Validate.isTrue(price > 0, "price has to be positive");
 
@@ -681,11 +846,11 @@ public abstract class AbstractPlayerShopkeeper
 			Currency highCurrency = Currencies.getHigh();
 			int highCurrencyAmount = Math.min(
 					price / highCurrency.getValue(),
-					highCurrency.getMaxStackSize()
-			);
+					highCurrency.getMaxStackSize());
 			if (highCurrencyAmount > 0) {
 				remainingPrice -= (highCurrencyAmount * highCurrency.getValue());
-				UnmodifiableItemStack highCurrencyItem = highCurrency.getItemData().createUnmodifiableItemStack(highCurrencyAmount);
+				UnmodifiableItemStack highCurrencyItem = highCurrency.getItemData()
+						.createUnmodifiableItemStack(highCurrencyAmount);
 				item1 = highCurrencyItem; // Using the first slot
 			}
 		}
@@ -706,7 +871,8 @@ public abstract class AbstractPlayerShopkeeper
 			if (item1 == null) {
 				item1 = currencyItem;
 			} else {
-				// The first item of the trading recipe is already used by the high currency item:
+				// The first item of the trading recipe is already used by the high currency
+				// item:
 				item2 = currencyItem;
 			}
 		}
@@ -714,13 +880,13 @@ public abstract class AbstractPlayerShopkeeper
 		return new SKTradingRecipe(itemBeingSold, item1, item2, outOfStock);
 	}
 
-	// Returns null (and logs a warning) if the price cannot be represented correctly by currency
+	// Returns null (and logs a warning) if the price cannot be represented
+	// correctly by currency
 	// items.
 	protected final @Nullable TradingRecipe createBuyingRecipe(
 			UnmodifiableItemStack itemBeingBought,
 			int price,
-			boolean outOfStock
-	) {
+			boolean outOfStock) {
 		Currency currency = Currencies.getBase();
 		int maxPrice = currency.getStackValue();
 		if (price > maxPrice) {
@@ -789,10 +955,12 @@ public abstract class AbstractPlayerShopkeeper
 		super.onTick();
 	}
 
-	// Deletes the shopkeeper if the container is no longer present (e.g. if it got removed
+	// Deletes the shopkeeper if the container is no longer present (e.g. if it got
+	// removed
 	// externally by another plugin, such as WorldEdit, etc.):
 	private void onTickCheckDeleteIfContainerBroken() {
-		if (!Settings.deleteShopkeeperOnBreakContainer) return;
+		if (!Settings.deleteShopkeeperOnBreakContainer)
+			return;
 		if (!checkContainerLimiter.request()) {
 			return;
 		}
@@ -800,7 +968,8 @@ public abstract class AbstractPlayerShopkeeper
 		// This checks if the block is still a valid container:
 		Block containerBlock = this.getContainer();
 		if (containerBlock != null && !ShopContainers.isSupportedContainer(containerBlock.getType())) {
-			// Note: If this shopkeeper is deleted due to the chest having been broken, we will
+			// Note: If this shopkeeper is deleted due to the chest having been broken, we
+			// will
 			// trigger a delayed save after the ticking of the shopkeepers.
 			SKShopkeepersPlugin.getInstance().getRemoveShopOnContainerBreak().handleBlockBreakage(containerBlock);
 		}

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlayerShopEditorLayout.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlayerShopEditorLayout.java
@@ -7,15 +7,18 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import com.nisovin.shopkeepers.SKShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.shopkeeper.player.PlayerShopkeeper;
 import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.config.Settings.DerivedSettings;
 import com.nisovin.shopkeepers.lang.Messages;
+import com.nisovin.shopkeepers.members.ShopkeeperMembers;
 import com.nisovin.shopkeepers.ui.editor.ActionButton;
 import com.nisovin.shopkeepers.ui.editor.Button;
 import com.nisovin.shopkeepers.ui.editor.EditorView;
 import com.nisovin.shopkeepers.ui.editor.ShopkeeperActionButton;
 import com.nisovin.shopkeepers.ui.editor.ShopkeeperEditorLayout;
+import com.nisovin.shopkeepers.util.bukkit.TextUtils;
 import com.nisovin.shopkeepers.util.inventory.ItemUtils;
 import com.nisovin.shopkeepers.util.java.StringUtils;
 
@@ -36,6 +39,7 @@ public class PlayerShopEditorLayout extends ShopkeeperEditorLayout {
 
 		this.addButtonOrIgnore(this.createContainerButton());
 		this.addButtonOrIgnore(this.createTradeNotificationsButton());
+		this.addButtonOrIgnore(this.createMembersButton());
 	}
 
 	protected @Nullable Button createContainerButton() {
@@ -56,7 +60,8 @@ public class PlayerShopEditorLayout extends ShopkeeperEditorLayout {
 					// Open the shop container inventory:
 					Player player = editorView.getPlayer();
 					PlayerShopkeeper shopkeeper = getShopkeeper();
-					if (!player.isValid() || !shopkeeper.isValid()) return;
+					if (!player.isValid() || !shopkeeper.isValid())
+						return;
 
 					shopkeeper.openContainerWindow(player);
 				});
@@ -77,12 +82,10 @@ public class PlayerShopEditorLayout extends ShopkeeperEditorLayout {
 				ItemStack iconItem = Settings.tradeNotificationsItem.createItemStack();
 				String state = shopkeeper.isNotifyOnTrades() ? Messages.stateEnabled : Messages.stateDisabled;
 				String displayName = StringUtils.replaceArguments(Messages.buttonTradeNotifications,
-						"state", state
-				);
+						"state", state);
 				List<? extends String> lore = StringUtils.replaceArguments(
 						Messages.buttonTradeNotificationsLore,
-						"state", state
-				);
+						"state", state);
 				ItemUtils.setDisplayNameAndLore(iconItem, displayName, lore);
 				return iconItem;
 			}
@@ -91,6 +94,49 @@ public class PlayerShopEditorLayout extends ShopkeeperEditorLayout {
 			protected boolean runAction(EditorView editorView, InventoryClickEvent clickEvent) {
 				var shopkeeper = (AbstractPlayerShopkeeper) this.getShopkeeper();
 				shopkeeper.setNotifyOnTrades(!shopkeeper.isNotifyOnTrades());
+				return true;
+			}
+		};
+	}
+
+	protected @Nullable Button createMembersButton() {
+		return new ActionButton() {
+			@Override
+			public @Nullable ItemStack getIcon(EditorView editorView) {
+				ItemStack iconItem = DerivedSettings.membersButtonItem.createItemStack();
+				List<? extends String> lore = Messages.buttonMembersLore;
+				ItemUtils.setDisplayNameAndLore(iconItem, Messages.buttonMembers, lore);
+				return iconItem;
+			}
+
+			@Override
+			protected boolean runAction(EditorView editorView, InventoryClickEvent clickEvent) {
+				Player player = editorView.getPlayer();
+				AbstractPlayerShopkeeper shopkeeper = getShopkeeper();
+
+				// Only the owner can manage members:
+				if (!shopkeeper.isOwner(player))
+					return false;
+
+				if (clickEvent.isLeftClick()) {
+					// Add member: close editor, prompt for name via chat
+					editorView.closeDelayed();
+					ShopkeeperMembers shopkeeperMembers = SKShopkeepersPlugin.getInstance().getShopkeeperMembers();
+					shopkeeperMembers.startAddMember(player, shopkeeper);
+					TextUtils.sendMessage(player, Messages.typeMemberName);
+				} else if (clickEvent.isRightClick()) {
+					if (clickEvent.isShiftClick()) {
+						// List members
+						ShopkeeperMembers shopkeeperMembers = SKShopkeepersPlugin.getInstance().getShopkeeperMembers();
+						shopkeeperMembers.listMembers(player, shopkeeper);
+					} else {
+						// Remove member: close editor, prompt for name via chat
+						editorView.closeDelayed();
+						ShopkeeperMembers shopkeeperMembers = SKShopkeepersPlugin.getInstance().getShopkeeperMembers();
+						shopkeeperMembers.startRemoveMember(player, shopkeeper);
+						TextUtils.sendMessage(player, Messages.typeRemoveMemberName);
+					}
+				}
 				return true;
 			}
 		};

--- a/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlayerShopEditorViewProvider.java
+++ b/modules/main/src/main/java/com/nisovin/shopkeepers/shopkeeper/player/PlayerShopEditorViewProvider.java
@@ -5,6 +5,7 @@ import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.shopkeepers.api.ShopkeepersPlugin;
 import com.nisovin.shopkeepers.api.shopkeeper.Shopkeeper;
+import com.nisovin.shopkeepers.api.shopkeeper.player.MemberPermission;
 import com.nisovin.shopkeepers.api.util.UnmodifiableItemStack;
 import com.nisovin.shopkeepers.config.Settings;
 import com.nisovin.shopkeepers.currency.Currencies;
@@ -24,13 +25,14 @@ import com.nisovin.shopkeepers.util.logging.Log;
 
 public abstract class PlayerShopEditorViewProvider extends ShopkeeperEditorViewProvider {
 
-	// Note: In the editor item1 is representing the low cost item and item2 the high cost item, but
-	// in the corresponding trading recipe they will be swapped if they are both present.
+	// Note: In the editor item1 is representing the low cost item and item2 the
+	// high cost item, but
+	// in the corresponding trading recipe they will be swapped if they are both
+	// present.
 
 	protected PlayerShopEditorViewProvider(
 			AbstractPlayerShopkeeper shopkeeper,
-			TradingRecipesAdapter tradingRecipesAdapter
-	) {
+			TradingRecipesAdapter tradingRecipesAdapter) {
 		super(SKDefaultUITypes.EDITOR(), shopkeeper, tradingRecipesAdapter);
 	}
 
@@ -41,10 +43,13 @@ public abstract class PlayerShopEditorViewProvider extends ShopkeeperEditorViewP
 
 	@Override
 	public boolean canAccess(Player player, boolean silent) {
-		if (!super.canAccess(player, silent)) return false;
+		if (!super.canAccess(player, silent))
+			return false;
 
-		// Check the owner:
-		if (!this.getShopkeeper().isOwner(player)
+		AbstractPlayerShopkeeper shopkeeper = this.getShopkeeper();
+		// Check the owner or member:
+		if (!shopkeeper.isOwner(player)
+				&& !this.canMemberAccess(player)
 				&& !PermissionUtils.hasPermission(player, ShopkeepersPlugin.BYPASS_PERMISSION)) {
 			if (!silent) {
 				this.debugNotOpeningUI(player, "Player is not owning this shop.");
@@ -55,18 +60,26 @@ public abstract class PlayerShopEditorViewProvider extends ShopkeeperEditorViewP
 		return true;
 	}
 
+	private boolean canMemberAccess(Player player) {
+		AbstractPlayerShopkeeper shopkeeper = this.getShopkeeper();
+		if (!shopkeeper.isMember(player))
+			return false;
+		MemberPermission level = Settings.DerivedSettings.memberPermissionLevel;
+		return level == MemberPermission.CHEST_AND_TRADES || level == MemberPermission.FULL;
+	}
+
 	@Override
 	protected ShopkeeperEditorLayout createLayout() {
 		return new PlayerShopEditorLayout(this.getShopkeeper());
 	}
 
 	// Note: In case the cost is too large to represent, it sets the cost to zero.
-	// (So opening and closing the editor window will remove the offer, instead of setting the costs
+	// (So opening and closing the editor window will remove the offer, instead of
+	// setting the costs
 	// to a lower value than what was previously somehow specified)
 	protected static TradingRecipeDraft createTradingRecipeDraft(
 			@ReadOnly ItemStack resultItem,
-			int cost
-	) {
+			int cost) {
 		ItemStack highCostItem = null;
 		ItemStack lowCostItem = null;
 
@@ -77,8 +90,7 @@ public abstract class PlayerShopEditorViewProvider extends ShopkeeperEditorViewP
 			if (remainingCost > Settings.highCurrencyMinCost) {
 				highCost = Math.min(
 						(remainingCost / highCurrency.getValue()),
-						highCurrency.getMaxStackSize()
-				);
+						highCurrency.getMaxStackSize());
 			}
 			if (highCost > 0) {
 				remainingCost -= (highCost * highCurrency.getValue());

--- a/modules/shared/nmsModulePaper.gradle
+++ b/modules/shared/nmsModulePaper.gradle
@@ -21,6 +21,13 @@ dependencies {
 	implementation project(':shopkeepers-main')
 	paperweight.paperDevBundle(craftbukkitVersion) // Includes CraftBukkit and PaperAPI
 
+	// Workaround: Some Paper dev-bundle snapshots declare this dependency with an empty version.
+	constraints {
+		implementation('net.kyori:adventure-text-serializer-ansi:4.25.0') {
+			because 'Paper dev-bundle may omit the version for this dependency'
+		}
+	}
+
 	testImplementation libs.junit
 	testImplementation libs.asm
 }


### PR DESCRIPTION
## Summary

This PR adds support for **shop members** so shop owners can grant shared access to other players.

Members can be added, removed, and listed from the player shop editor, and their effective access is configurable. Depending on the configured permission level, members can access the shop container and/or edit trades without transferring ownership of the shop.

Fixes #342

## What changed

- Added a shop member API to `PlayerShopkeeper`
  - introduced `MemberPermission` with:
    - `CHEST_ONLY`
    - `CHEST_AND_TRADES`
    - `FULL`
  - added member management methods for:
    - adding/removing members
    - listing members
    - membership checks
    - owner-or-member checks

- Implemented member storage on player shopkeepers
  - members are persisted with UUID + last known name
  - added serialization/deserialization for the stored member list
  - added validation for duplicates, owner exclusion, and max member count

- Added new configuration/settings
  - `member-permissions`
  - `max-members-per-shop`
  - `members-item`

- Added member-related messages
  - prompts and feedback for add/remove/list flows
  - limit/duplicate/not-found cases
  - editor button text and lore

- Integrated members into existing behavior
  - protected shop containers now allow access for members
  - player shop editor access now supports members when the configured permission level allows it

- Added a Members button to the player shop editor
  - left-click: add member
  - right-click: remove member
  - shift-right-click: list members
  - member management remains owner-only

- Added `ShopkeeperMembers` chat input flow
  - resolves player names
  - supports add/remove flows from chat input
  - wired into plugin enable/disable lifecycle

## Notes

- This keeps ownership unchanged while allowing limited shared access.
- The exact capabilities of members are controlled through config.
- This branch also includes a small Paper dev-bundle build workaround for `adventure-text-serializer-ansi` which you may want to change.